### PR TITLE
online doc: change IoTDB DB example to use a 'device'

### DIFF
--- a/docs/docs-gen/content/manuals/apache-iotdb.md
+++ b/docs/docs-gen/content/manuals/apache-iotdb.md
@@ -59,7 +59,7 @@ $ bash <iotdb path>/sbin/start-cli.sh -h <server hostname/ip>
 ```
 2. Create database from CLI command line:
 ```
-IoTDB > create database root.test2.dev1
+IoTDB > create database root.test2
 ```
 3. Create timeseries from CLI command line:
 ```
@@ -93,9 +93,12 @@ rpcPort=6667
 user=root
 pass=root
 
-bash ./sbin/start-cli.sh -h ${host} -p ${rpcPort} -u ${user} -pw ${pass} -e "create database root.test2.dev1"
+bash ./sbin/start-cli.sh -h ${host} -p ${rpcPort} -u ${user} -pw ${pass} -e "create database root.test2"
+
 bash ./sbin/start-cli.sh -h ${host} -p ${rpcPort} -u ${user} -pw ${pass} -e "CREATE ALIGNED TIMESERIES root.test2.dev1(\`Vehicle.CurrentLocation.Longitude\` FLOAT, \`Vehicle.CurrentLocation.Latitude\` FLOAT, \`Vehicle.Cabin.Infotainment.HMI.DistanceUnit\` TEXT)"
+
 bash ./sbin/start-cli.sh -h ${host} -p ${rpcPort} -u ${user} -pw ${pass} -e "insert into root.test2.dev1(\`Vehicle.CurrentLocation.Longitude\`, \`Vehicle.CurrentLocation.Latitude\`, \`Vehicle.Cabin.Infotainment.HMI.DistanceUnit\`) values(-42.4567, 22.1234, 'MILES')"
+
 bash ./sbin/start-cli.sh -h ${host} -p ${rpcPort} -u ${user} -pw ${pass} -e "select last * from root.test2.dev1"
 ```
 


### PR DESCRIPTION
Currently the example in IoTDB guide of the documentation site has a one tier database/device path with the database root.test2.dev1 off which the VSS measurements are added. This causes issues when you want to select all data, e.g. 'select * from root.test2.dev1' will create an error.

It is best to have a 'device' separate from the 'database' in IoTDB terms. So simply change the guide so that the 'create database' is for 'root.test2' only, which will solve both issues.