### PR TITLE
minor: vehicle-speed-downsample-iotdb example README and root project README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For further information please see the
 ## Getting started
 A good place to start is the overview in the documentation which introduces why the project exists, the logical concept and its implementation.
 
-Once you are ready to jump into some code the docker deployment readme explains building and starting the playground. Whilst the hello-world example provides simple examples of accessing the data store directly and using the data server to get/set data using the [Vehicle Information Service Specification (VISS)](https://github.com/COVESA/vehicle-information-service-specification) API. Hello-world can also be used as a sanity test that the playground is operating as expected.
+Once you are ready to jump into some code the docker deployment readme explains building and starting the playground. Whilst the [examples](https://github.com/COVESA/cdsp/tree/main/examples) folder contains a variety of examples to explore.
 
 ### Cloning the source repository
 The playground git source repository contains git submodules which need to be initialized either during the clone or afterwords as shown below.
@@ -35,7 +35,11 @@ git submodule update --init --recursive
 See the github issues for this project with the `bug` label.
 
 ## Project resources
-The project originated in the COVESA [data architecture team](https://wiki.covesa.global/display/WIK4/Central+Data+Service+Playground).
+The project originated in the COVESA [data architecture team](https://wiki.covesa.global/display/WIK4/Data+Expert+Group%3A+Architecture+and+Infrastructure).
+
+The project maintainers are:
++ Stephen Lawrence, Renesas Electronics
++ Christian Muehlbauer, BMW AG
 
 |Resource|Notes|
 |---|---|

--- a/examples/vehicle-speed-downsample-iotdb/README.md
+++ b/examples/vehicle-speed-downsample-iotdb/README.md
@@ -94,9 +94,23 @@ We will use the IoTDB CLI client to send SQL commands on its command line to the
     ~~~
     $ docker exec -ti iotdb-service /iotdb/sbin/start-cli.sh -h iotdb-service
     ~~~
+
+#### Data Quality Library setup
+The IoTDB Data Library is an optional install. To call the functions they must first be registered in the running IoTDB instance, which you only need to do once. The script /iotdb/sbin/register-UDF.sh is included in the IoTDB image to do this for you.
+
+Execute the script using the Docker `exec` command:
+
+~~~
+$ sudo docker exec -ti iotdb-service /iotdb/sbin/register-UDF.sh
+~~~
+
+Info: See the online documentation site for [details](https://covesa.github.io/cdsp/manuals/apache-iotdb/#setup)
+
 ### Import the dataset
 
 1. Create the database in IoTDB into which we will import
+
+    Using the IoTDB CLI client:
     ~~~sql
     IoTDB> create database root.test2
     ~~~
@@ -109,7 +123,7 @@ We will use the IoTDB CLI client to send SQL commands on its command line to the
     $ cp vehicle_speed_rl_dataset.csv ../../docker/data
     ~~~
 
-    2.2. Import the dataset:
+    2.2. Import the dataset
 
     To import the dataset into IoTDB we need to execute the `import-csv.sh` tool in the IoTDB image. That can be done from the host terminal using the docker `exec` command.
     ~~~


### PR DESCRIPTION
1. Add vehicle-speed-downsample-iotdb README note to explain that the Data Quality Library functions must be registered before they can be used.
2. Minor updates to the root project README. Mainly adding the list of maintainers

See commit messages for details
