### PR TITLE
online doc: add down-sample to example page and improve readability

### DIFF
--- a/docs/docs-gen/content/examples/_index.md
+++ b/docs/docs-gen/content/examples/_index.md
@@ -3,38 +3,59 @@ title: "Playground examples"
 weight: 30
 ---
 
-Learn how to use the playground by stepping through examples.
+The following examples are intended to show how to use playground components and how they can be combined to build larger systems.
+
+They are grouped by categories to help discovery of appropriate examples from different viewpoints.
 
 Note: There is not a separate section for the VSS data model because the vast majority of the examples will be making use of it.
 
 ## Getting started
-[Docker sanity test](https://github.com/COVESA/cdsp/blob/main/docker/README.md) \| [Hello-world](https://github.com/COVESA/cdsp/tree/main/examples/cdsp-hello-world)
+
+| Name | Relationship to the category |
+|------|-------------|
+| [Docker sanity test](https://github.com/COVESA/cdsp/tree/main/docker#deploy-with-docker-compose) | Simple sanity test for the Playground Docker deployment |
+| [Hello-world](https://github.com/COVESA/cdsp/tree/main/examples/cdsp-hello-world) | Simple "hello-world" example|
 
 ## Data Layer, Processing and Analysis
-Data Reduction \| Data Quality \| Events \| Data Streams etc.
+Topic examples: Data Reduction, Data Quality, Events, Data Streams etc.
 
-Tip: well you wait for some examples consider how you could use the [IoTDB data processing functions]({{< ref "apache-iotdb#data-processing-functions" >}} "IoTDB data processing").
+| Name | Relationship to the category |
+|------|-------------|
+| [vehicle-speed-downsample-iotdb](https://github.com/COVESA/cdsp/tree/main/examples/vehicle-speed-downsample-iotdb) | Accurately down-sample a timeseries of pre-recorded high frequency VSS `Vehicle.Speed` data using the IoTDB Data Quality Library|
+
+Tip: well you wait for more examples consider how you could use the [IoTDB data processing functions]({{< ref "apache-iotdb#data-processing-functions" >}} "IoTDB data processing").
 
 ## Knowledge Layer, Reasoning and Data Models
-Data Layer Connector \| A \| B \| C etc.
+Topic examples: Knowledge Layer Connector, Data Layer Connector etc.
 
 ## Feeders
-[RemotiveLabs](https://github.com/COVESA/cdsp/tree/main/examples/remotivelabs-feeder) \| WAII VISS \| etc.
+Topic examples: Virtual signal platforms, VISSR etc.
+
+| Name | Relationship to the category |
+|------|-------------|
+| [RemotiveLabs feeder](https://github.com/COVESA/cdsp/tree/main/examples/remotivelabs-feeder) | Example bridge that streams vehicle data from the RemotiveLabs cloud platform into the IoTDB data store |
+
 
 ## COVESA Touchpoints
-A \| B \| C
+Topic examples: Low level vehicle abstraction, Mobile devices, Car2Cloud / Cloud etc. 
 
 ## COVESA Technologies
-vsome/ip (SOME/IP) \| uServices \| Vehicle API \| VISS etc.
+Topic examples: vsome/ip (SOME/IP), uServices, Vehicle API, VISS etc.
 
 ## Databases
-Apache IoTDB \| MongoDB Realm \| Redis/SQLite/memcache etc.
+Topic examples: Apache IoTDB, MongoDB Realm, Redis/SQLite/memcache etc.
+
+ Name | Relationship to the category |
+|------|-------------|
+| [vehicle-speed-downsample-iotdb](https://github.com/COVESA/cdsp/tree/main/examples/vehicle-speed-downsample-iotdb) | Using the IoTDB [Data Quality Library ]({{< ref "apache-iotdb#data-processing-functions" >}} "IoTDB Data Quality Library") for advanced (VSS) timeseries data processing|
+| [RemotiveLabs feeder](https://github.com/COVESA/cdsp/tree/main/examples/remotivelabs-feeder) | Example of streaming (writing) southbound (VSS) timeseries data into IoTDB|
+
 
 ## Frameworks / Protocols
-vsome/ip (SOME/IP) \| VISS \| uServices/uProtocol/Capabilities \| Vehicle API \| MQTT \| Kafka \| Apache Zeppelin etc.
+Topic examples: vsome/ip (SOME/IP), VISS, uServices/uProtocol/Capabilities, Vehicle API, MQTT, Kafka, Apache Zeppelin etc.
 
 ## Big data
-Hadoop \| Flink \| Spark \| Cloud DB \| Nifi etc.
+Topic examples: Hadoop, Flink, Spark, Cloud DB,  Nifi etc.
 
 ## Other examples
-A \| B \| C
+Topics that do not fit into the groups above.


### PR DESCRIPTION
1. Add the vehicle-speed-downsample-iotdb example to the example page of the online documentation. 
2. At the same time take the opportunity to improve the readability of the page and prepare for more examples by adding tables to the categories listing the examples and their relevance to the category.

Resolves #55 
