### PR TITLE
Update VISSR (VISS data server) for VISS v3

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -50,13 +50,6 @@ There is a current issue with the upstream VISSR VISS Server Dockerfile in which
 
 If your project requires Access Grant support please discuss enabling it with the VISSR community.
 
-### Generate `vss_vissv2.binary`
-The VISSR server component requires a file called `vss_vissv2.binary` to understand the VSS tree it must work with. Unfortunately, VISSR provides no default file and you must therefore generate it yourself.
-
-Instructions for doing that can be found in the VISSR documentation site [here](https://covesa.github.io/vissr/server/#vss-tree-configuration)
-
-Tip: The playground maintainers have found that the method involving running `make binary` in a git clone of the VSS source tree to generate the file is straight forward. Note: check the VSS readme for the python requirements for the tooling.
-
 ### Tip: Corporate CA security (download error "tls: failed to verify certificate:")
 If you are working behind a corporate security system that places a _man-in-the-middle_ between your host and the internet you may see security errors when artifacts are downloaded as part of the build process.
 
@@ -172,5 +165,3 @@ The following example uses the javascript HTML client from `vissr/client/client-
   Server: readyState=3, status=200
   Server: {"data":{"dp":{"ts":"2024-01-10T14:56:48Z","value":"Data-not-found"},"path":"Vehicle.Speed"},"ts":"2024-01-10T14:56:48Z"}
 ```
-
-You can query what VSS nodes the server understands by asking for the VSS path list using the URL `http://localhost:8081/vsspathlist`. Entering that URL in your web browser will typically give you a graphical rendering of the JSON data returned.

--- a/docs/docs-gen/content/examples/_index.md
+++ b/docs/docs-gen/content/examples/_index.md
@@ -35,24 +35,31 @@ Topic examples: Virtual signal platforms, VISSR etc.
 |------|-------------|
 | [RemotiveLabs feeder](https://github.com/COVESA/cdsp/tree/main/examples/remotivelabs-feeder) | Example bridge that streams vehicle data from the RemotiveLabs cloud platform into the IoTDB data store |
 
-
 ## COVESA Touchpoints
 Topic examples: Low level vehicle abstraction, Mobile devices, Car2Cloud / Cloud etc. 
 
 ## COVESA Technologies
 Topic examples: vsome/ip (SOME/IP), uServices, Vehicle API, VISS etc.
 
+| Name | Relationship to the category |
+|------|-------------|
+| [VISSR/VISS hello-world](https://covesa.github.io/vissr/build-system/hello-world/) | hello-world tutorial for making VISS requests using VISSR in the upstream VISSR project |
+| [VISS transport examples](https://raw.githack.com/COVESA/vehicle-information-service-specification/main/spec/VISSv3.0_TransportExamples.html) | Examples in the VISS Specification for making VISS requests and the responses for various transport protocols |
+
 ## Databases
 Topic examples: Apache IoTDB, MongoDB Realm, Redis/SQLite/memcache etc.
 
- Name | Relationship to the category |
+| Name | Relationship to the category |
 |------|-------------|
 | [vehicle-speed-downsample-iotdb](https://github.com/COVESA/cdsp/tree/main/examples/vehicle-speed-downsample-iotdb) | Using the IoTDB [Data Quality Library ]({{< ref "apache-iotdb#data-processing-functions" >}} "IoTDB Data Quality Library") for advanced (VSS) timeseries data processing|
-| [RemotiveLabs feeder](https://github.com/COVESA/cdsp/tree/main/examples/remotivelabs-feeder) | Example of streaming (writing) southbound (VSS) timeseries data into IoTDB|
-
+| [RemotiveLabs feeder](https://github.com/COVESA/cdsp/tree/main/examples/remotivelabs-feeder) | Example of streaming (writing) southbound (VSS) timeseries data into IoTDB |
 
 ## Frameworks / Protocols
 Topic examples: vsome/ip (SOME/IP), VISS, uServices/uProtocol/Capabilities, Vehicle API, MQTT, Kafka, Apache Zeppelin etc.
+
+| Name | Relationship to the category |
+|------|-------------|
+| VISS | Find examples in the COVESA Technologies section and or search for VISS/VISSR in this page |
 
 ## Big data
 Topic examples: Hadoop, Flink, Spark, Cloud DB,  Nifi etc.


### PR DESCRIPTION
Currently CDSP points at a VISSR commit that implements VISS v2. Since then the upstream VISS community has been working towards VISS v3 and updated the VISSR implementation of it accordingly.

Allow CDSP users to experiment with this new work by updating the CDSP git submodule to point at the latest upstream VISSR commit fbb02dec on the master branch.

Integration was sanity tested using the VISSR HTML client to get/set VSS data into the Apache IoTDB DB.

See task issue https://github.com/COVESA/cdsp/issues/59 for details