### PR TITLE
doc: change links to upstream IoTDB doc to point at URLs for v1.3.3

### DIFF
--- a/docs/docs-gen/content/manuals/apache-iotdb.md
+++ b/docs/docs-gen/content/manuals/apache-iotdb.md
@@ -14,7 +14,7 @@ The IoTDB project [website](https://iotdb.apache.org/) has extensive documentati
 Info: The intention is to add more information such as a guide for feeder integration as the project progresses.
 
 ## Integrating VSS data into the IoTDB data model
-The ["Basic Functions"](https://iotdb.apache.org/UserGuide/latest/Basic-Concept/Data-Model-and-Terminology.html) section of the IoTDB documentation introduces the IoTDB data model, data types, encoding and compression.
+The ["Basic Functions"](https://iotdb.apache.org/UserGuide/V1.3.3/Basic-Concept/Data-Model-and-Terminology.html) section of the IoTDB documentation introduces the IoTDB data model, data types, encoding and compression.
 
 In IoTDB terminology *measurement* is the key in a key/value pair. In VSS terms the leaf node name. The timeseries is the record of the measurement on the time axis. A timeseries is a series of time/value data points.
 
@@ -50,7 +50,7 @@ Note: IoTDB has data type detection so creating a schema for the timeseries in s
 IoTDB has a very extensive collection of integrations, tools, clients and APIs that could be used to achieve this.
 
 ### Example using the IoTDB CLI client
-The following tutorial shows an example using the [IoTDB CLI client](https://iotdb.apache.org/UserGuide/latest/Tools-System/CLI.html), using two methods. Firstly, in interactive mode where you type the commands and then sending the same commands in batch command mode.
+The following tutorial shows an example using the [IoTDB CLI client](https://iotdb.apache.org/UserGuide/V1.3.3/Tools-System/CLI.html), using two methods. Firstly, in interactive mode where you type the commands and then sending the same commands in batch command mode.
 
 
 1. Connect to the CLI client from your host:
@@ -127,7 +127,7 @@ IoTDB has an extensive collection of built-in data processing functions covering
 - Sampling Functions, such as `M4`.
 - Change Points Function, such as `CHANGE_POINTS`.
 
-A full function list with examples can be found in the upstream [IoTDB Function reference manual](https://iotdb.apache.org/UserGuide/latest/SQL-Manual/Function-and-Expression.html).
+A full function list with examples can be found in the upstream [IoTDB Function reference manual](https://iotdb.apache.org/UserGuide/V1.3.3/SQL-Manual/Function-and-Expression.html).
 
 ### Data Quality Library functions
 The IoTDB project also maintains a Data Quality Library which provides an additional collection of functions covering:
@@ -140,7 +140,7 @@ The IoTDB project also maintains a Data Quality Library which provides an additi
 - Series Discovery, such as `ConsecutiveSequences`.
 - Machine Learning, such as `AR`.
 
-A full function list with examples can be found in the upstream [IoTDB UDF Data Quality Library reference manual](https://iotdb.apache.org/UserGuide/latest/SQL-Manual/UDF-Libraries_apache.html).
+A full function list with examples can be found in the upstream [IoTDB UDF Data Quality Library reference manual](https://iotdb.apache.org/UserGuide/V1.3.3/SQL-Manual/UDF-Libraries_apache.html).
 
 #### Setup
 In the upstream IoTDB project the library is an optional install.
@@ -157,7 +157,7 @@ Steps:
 
 
 ### User Defined functions
-IoTDB also allows you to integrate your own functions as User Defined Functions (UDF). The [UDF development section](https://iotdb.apache.org/UserGuide/latest/User-Manual/UDF-development.html) of the IoTDB documentation explains how to develop and register your own.
+IoTDB also allows you to integrate your own functions as User Defined Functions (UDF). The [UDF development section](https://iotdb.apache.org/UserGuide/V1.3.3/User-Manual/UDF-development.html) of the IoTDB documentation explains how to develop and register your own.
 
 ## VISSR (VISS) integration
 As part of the initial development of the playground the team extended VISSR to support connections to Apache IoTDB as a VISSR data store backend and upstreamed the support.

--- a/examples/vehicle-speed-downsample-iotdb/README.md
+++ b/examples/vehicle-speed-downsample-iotdb/README.md
@@ -35,10 +35,10 @@ The dataset contains just over 13500 values recorded over approximately 5 minute
 ### Load
 In the example we will import the dataset into a VSS `Vehicle.Speed` timeseries within IoTDB.
 
-IoTDB provides import/export tools for its native TsFile file format, SQL and CSV and which are included in the runtime image. We will use the [`import-data.sh`](https://iotdb.apache.org/UserGuide/latest/Tools-System/Data-Import-Tool.html) tool to perform the import.
+IoTDB provides import/export tools for its native TsFile file format, SQL and CSV and which are included in the runtime image. We will use the [`import-data.sh`](https://iotdb.apache.org/UserGuide/V1.3.3/Tools-System/Data-Import-Tool.html) tool to perform the import.
 
 ### Transform
-IoTDB has a library of Data Quality functions which includes the function [`Sample`](https://iotdb.apache.org/UserGuide/latest/SQL-Manual/UDF-Libraries_apache.html#sample) for sampling. Sample has three sampling methods: `Reservoir`, `Isometric` and `Triangle`. 
+IoTDB has a library of Data Quality functions which includes the function [`Sample`](https://iotdb.apache.org/UserGuide/V1.3.3/SQL-Manual/UDF-Libraries_apache.html#sample) for sampling. Sample has three sampling methods: `Reservoir`, `Isometric` and `Triangle`. 
 
 Sample function:
 
@@ -64,7 +64,7 @@ The following screenshot shows the results graphed in Grafana. The green graph i
 *Figure 1: Grafana visualisation of the results. Key: Green=input data, yellow=down-sampled result*
 
 Tips:
-+ Documentation for each Sample method and the other functions can be found in the [IoTDB library documentation](https://iotdb.apache.org/UserGuide/latest/SQL-Manual/UDF-Libraries_apache.html).
++ Documentation for each Sample method and the other functions can be found in the [IoTDB library documentation](https://iotdb.apache.org/UserGuide/V1.3.3/SQL-Manual/UDF-Libraries_apache.html).
 
 + Triangle uses a *Largest-Triangle-Three-Buckets (LTTB)* algorithm to calculate the output timeseries. Details of which can be found in the originating academic research: [Downsampling Time Series for Visual Representation, Sveinn Steinarsson, 2013](https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf)
 
@@ -106,7 +106,7 @@ $ sudo docker exec -ti iotdb-service /iotdb/sbin/register-UDF.sh
 
 Info: See the online documentation site for [details](https://covesa.github.io/cdsp/manuals/apache-iotdb/#setup)
 
-Tip: If for some reason you are failing to register the Data Quality Library, substitute one of the [built-in sample functions](https://iotdb.apache.org/UserGuide/latest/SQL-Manual/Operator-and-Expression.html#sample-functions) rather than `Sample()` in the SQL below.
+Tip: If for some reason you are failing to register the Data Quality Library, substitute one of the [built-in sample functions](https://iotdb.apache.org/UserGuide/V1.3.3/SQL-Manual/Operator-and-Expression.html#sample-functions) rather than `Sample()` in the SQL below.
 
 ### Import the dataset
 
@@ -327,7 +327,7 @@ It costs 0.028s
 
 ### Suggested next steps
 + Repeat the query with the same input data, but with different `k` parameter values to see what affects the number of samples has on the accuracy of the trace compared to the input data.
-+ Amend the query with other [SQL clauses](https://iotdb.apache.org/UserGuide/latest/Basic-Concept/Query-Data.html) to shape what you are interested in, e.g. use `WHERE` to define a time filter.
++ Amend the query with other [SQL clauses](https://iotdb.apache.org/UserGuide/V1.3.3/Basic-Concept/Query-Data.html) to shape what you are interested in, e.g. use `WHERE` to define a time filter.
 + A great way to explore these sampling queries is by using Grafana as discussed below.
 + Try the other [IoTDB data processing functions](https://covesa.github.io/cdsp/manuals/apache-iotdb/#data-processing-functions)
 
@@ -345,7 +345,7 @@ This ability to use the same SQL query in the IoTDB CLI Client, any code and Gra
 
 ### Setup
 #### Grafana connection setup
-The IoTDB project maintains the IoTDB Grafana Plugin to allow Grafana to interact with IoTDB data sources using the IoTDB REST API. This Plugin has been upstreamed into the Grafana project and can be installed from Grafana. Installation and usage instructions can be found in the IoTDB [online documentation](https://iotdb.apache.org/UserGuide/latest/Ecosystem-Integration/Grafana-Plugin.html).
+The IoTDB project maintains the IoTDB Grafana Plugin to allow Grafana to interact with IoTDB data sources using the IoTDB REST API. This Plugin has been upstreamed into the Grafana project and can be installed from Grafana. Installation and usage instructions can be found in the IoTDB [online documentation](https://iotdb.apache.org/UserGuide/V1.3.3/Ecosystem-Integration/Grafana-Plugin.html).
 
 Note: The Plugin install instructions describe enabling the IoTDB REST API, which is disabled by default in IoTDB. This has already been done for you in the Playground IoTDB Docker image.
 


### PR DESCRIPTION
For reasons including ease of maintenance CDSP has pointed to the latest version of the upstream Apache IoTDB documentation when linking to pages. However upstream work in moving from IoTDB v1.3.3 to the 2.0.1 Beta has broken the navigation tree in the upstream documentation site.

Taking this as a sign that it is safer to point at the version of the upstream documentation for the specific version we are currently using change URLs in the CDSP documentation.