### PR TITLE
(WIP) doc site: add Community area to the site

### DIFF
--- a/docs/doc-site/content/community.md
+++ b/docs/doc-site/content/community.md
@@ -1,0 +1,9 @@
+---
+title: Community
+---
+
+## Project resources
+Links to the major project resources such as issue tracking and project management can be found in the project [README.md](https://github.com/COVESA/cdsp/blob/main/README.md#project-resources)
+
+## Presentations
+A list of community presentations about CDSP can be found in the COVESA CDSP wiki [page](https://covesa.atlassian.net/wiki/spaces/WIK4/pages/39067272/Central+Data+Service+Playground#Presentations).

--- a/docs/doc-site/hugo.yaml
+++ b/docs/doc-site/hugo.yaml
@@ -27,6 +27,9 @@ menu:
     - name: About
       pageRef: /docs/overview
       weight: 2
+    - name: Community
+      pageRef: /community
+      weight: 2
     - name: Contact ↗
       url: "https://github.com/COVESA/cdsp/blob/main/README.md#project-resources"
       weight: 3


### PR DESCRIPTION
STATUS: possible enhancement to doc site. Made public here as a WIP for discussion.

Add a Community area to the documentation site. Populate initial content by providing links to the major project resources and a list of the community CDSP presentations.