### PR TITLE
C4 Model: Remove Realm component

### DIFF
--- a/diagrams/CDSP-C4-Model-Container-diagram.drawio.svg
+++ b/diagrams/CDSP-C4-Model-Container-diagram.drawio.svg
@@ -1,15 +1,15 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: transparent; background-color: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1996px" height="1192px" viewBox="-0.5 -0.5 1996 1192" content="&lt;mxfile scale=&quot;1&quot; border=&quot;0&quot;&gt;&lt;diagram name=&quot;L2 Container&quot; id=&quot;fswv24dbm5Xq4Tad-Ww_&quot;&gt;7V1pl5pIF/41njPzoT3s6Edb7UnebJ22J5nkG2qpJAgOYC/z699aoSh2RcWEzozdlMWlKKjnVj13qZ463r785Vu7zQdvCZyeIi1feuqkpyimOYSfqOCVFBiqRgrWvr0kRXJcMLP/A7RQoqV7ewmCRMXQ85zQ3iULF57rgkWYKLN833tOVlt5TvKqO2sNUgWzheWkS7/ay3BDS2VjGH/xBtjrDb30QDHJF1uLVaZ3EmyspffMFanTnjr2PS8kf21fxsBBfcf6RZ1+3BrBt+lPz3d+aE/hm9W36Q0RdlfnlOgWfOCGVUV78x+oO+FpjrUAG9htwBd6XPtobWkvPdpbEADfhk9KkSZWaMFfM+A/AZ/VfXzd0bpjzw0t2+W+AouN6znemr4io5212AD41VvvcXLLak1AsPDtXWh7LqmG5aPrhfzFl+Titgs/vsxm6C1wl/DTCzfoivj7my16SwMi2bHm8I3FEnuK4cAOul3BFqIHFr7St8D4d++xL24C/I6OYAXZ2L3EX8K/1vQ3ljKPC3TaV4rOvoT9PBdPgGXkysnipf0UFelEGO5MKAy1wrC2O/iVOw927Fpch8JK+oS7AC+MtdMvumLdLpGLuoRKWcC2+QkpPfhGGuhf1rl68uEnOjGrw8TbVMoGiBKNxmhAxTeqwHGLX93Fq2O7cBSoUCi54YkMH8Ht88YOwQy+s6jkGYIgLNuEW/ROyah7vT08a/l+zgp8UgCPJHiEX79ba/FzjcvHtGtczwWow2zHGUe9pSrqSJkMaUdSrJQVeszVW+EfWG459hoNlwUc+fD1hw0Pfe8n4KpKU3MymsBvtiC0pks7pK3cebYb4gGvo9dO6sNeH0v4f/RCjWGZjI76ip5RmFVmJgtJJTlZllkxQ6IkXFpHd+AD+FisOX5uUvTkS2GPwhnEqhC8cAhHX4i/gAe7xodDSaLfahpVYRSvTF0nx8+xglA0ivobTjfITBVYFEnXkewYeOEf9C1khxSKD4DlL28xAh4LyEjMQzkOE7ilAPxko88Q4zhtxuj+7a8BuVKHsgegrFqIsjEqyuWYysOffBSIVgJNy1+wq0l1MFQEpBSmKmlQzQLaCBKbRF8zA36zIJlcokmcPhcu62q7cDlG3AfgWGiUBRt7lwe6dPJLUPNu9vl9LgB/sH5y+LsGsBl3AfqE41zFb6wP/t2DIMyf8eKRnIE7sOfDGzoeEPA4YBXmA09VKXRgVYTxXFTKQvMMUD26VUwD1ML72vCoFcIjcJcjtJqFR3PHW/x83MAVTi4mSml00yT0L0IvtpZFZ0LZd7bD5KTQbaCgf6ieM8cNQCPShivkNOBBSawJGhZl+SFf8GO/3c3oTUFQZSW0hpGaHIMlXIvT+p4fbry151rONC69BS92+A+q3dfp0TfWFvj35IUJQgev3ME9XC/CxiN4P2CuGHh7fwHKdB2c/lg+Go4lKw9FQvdZiHBZCOZjEHlK8hRZCEbF3SPtE6OlOkiipTHUkyLITdKzeM5BEGQoJYJIL6QEYUCN7rHxue8D2Hqoe95bcwSOt76NOrn+5Pf+Fb53bi74cig7C31gbdHFgv0cVZuDZQ49sfK9LfwltPHJ9sO9hUc+RCX8B7zVcOX5W0x7wY97x3olk5xYWBB6Puhm1r/vzFrvZtbdzPqUM2tZk6Qk5TFo19Q6F/a/RJA6Y5B6H0GqqAtm3ip8thCWSrPXIATbXNQvFEvIZ0J9jB1vv7x+bL4SDF7gn4tgsNEcBtfC3MF4oA2NJjHXVA0Tz/c7zL0o5prmtWDuGN66j0GQY5rtBRDnq+Nonpo5A58tvB24RXUt2lZYb7TbOXCxydHN2SB9DnRthivJxOhsBqEWch/eJAr2fFcXYn4pGJo1wFCccZaA49IKNtG5MZQpkgCNFC1T6GbgnzRekp9S9GVointSvWVUyIgWz70whCs7JsXz4bgRWwRvzXbXj96O4igtYHiMbvDeCiFWI4ED2HVaBhZ7IRxpHBZzdIYPR67lrh3AcRy3rveeDpDI6HhvLZfkuhK+Mcd7HjGHCVRCPSq4q4CXHTKmkwN4mb0fwJnWA6DWUMLY2OyMyIoI/OkTIKoCX2keeM4+BKNYD3Xa5OTcuJwkadSBlFImQ91IKxNTayE3LhoUc0jxXmR65Ejxu2A/x+wZo8Qj/gbO3ntJK2bHlreVLR90bHnvGLZcMxlHjvnyvqT0LkyZy1U5c7UiZ06R7waCscQsga8J2DkBq64bSZyVRfisyqpranL2Lw8FQTmseiyIVfRWKwx8J2beT23dpEuLCVjZrk3gTeLAm3j50UofLNfe7R06le3MoFcE7MMO2I8Adh7UY5NodUxHC/nXf/gDIknR2XEsCx+98kfHaYjGjKUx8KsqwycKOzdqetrbFPQrAl+jiTRMVehXBUGK0Rz0w9FjvXI16LKrwEqcfVO5bR9kk1ax5iEtOIcFeObtw82cck+MmcLPIEgrrercP+ivCVL6AHNeRPPEtltm4gVgiXB0jBDM3iJt5NHDtRWCZ/QY0MF0/Pcv4IneGQjKFJss9Yo0W2ch6DidmpyOsELQ5XbZB061IJgBDLgZbjXRRP8PQuL0FCQxI/Lnz24F0N4VgCwXAmW3BMhZAuRM3c2Dpu5NLSiaJomk06wVpL6mSwXweayvpZKEauNQVkgUpIuCcpYGtaf9upm8jqkXt0uoP9AKpv0Xo6jipQFWNWPHBm541FogEiEtMS/lrqMFwTbioHAh0VBows95ByUiprY0dDodr8q+DIiAfUBEEhmowtwKfgEH0G4NUaoalW4N0a0hTriGUBnV1JI1RCqUtVHMFiA6gcZJkP2VIlg7mC2F2QZDVTuY7WAWQqguWHNbi7OwZyKHzAB3ljT+9GU6Q4O5op+nCM2RvIltrX1r+2iHDsiF50cMuIs4LEtaktN6KHuPH0Fy3VZJf4wns/s/OZaI+5O2jGDWE3wt+pg+kibRpfcByTVDrq3BD5bqiDTqyQ72cHRSrQGr3j2jp+YvEDwswr0P+udTHb+qo2oh9NfE+OJ4W9SgJJAnoTUDv6t5iIbI7zNTaSQJHwGv0+6ZPIJnuYSm3TdzPDZ5p84sf81ONZxWNQiaIfIY4lSDLmeoBlM5h2aox+Kz6KtesXPmjMXHYkj1OCAmga+dh06b+fnicNOOn6/Hzx/mWpPNzysXJ+gph17Kz1NP80skPpB1AXJ1bZCUUZWNl81BiaRzpj44DVLDgYIzGtAw1wioKU3CW2E7yG4tZBdHp3aQXeIunwBZ8wi3SjmJ/YfZZhuGbKMiZOuXhGwBaAfM16U+ZIuZDIxWZKt553rPDu5aRXpvvWLe4+B8jQ+TO9iYT1/fw295wThDc49ZGB+AFXiclBT23/veE06+DJ/f3sG/kaERnRuAreXCcYofLRJDaQ/CvARnpDq6bDRty0Yj14n+bWs6mi4bzfGMydqxAkYiRcnPT5mYdyA6q7eWZX/rolQxND7peMD/6C1B/3/IQvkVzAM4g0PONIK4Ini3E81xaHP4VOqhD8CNY+OYWlIXMeSjORwj1iLkMpvRZGTSEg4R+1fJsd4pgoMUQXGQ7nUogi4vWYu5cxHwo9STLQH8U7nAf/XhYBG3vhCpmQCno+xomfbSMtw2MB0tcwCTLrApRxHpR3M8DbMyVYl0pSIrEzu6G0MhJvZ0fu+yJAu8jci2VOVtzGGJoIYc303BIXJQ4vieqi+f2/G92h5Q7Nk9Wc6eefqQFzHGGzSV2tV7jZNOBr1or6uDHVCV9Iot0tW8Alel+gq8Yk8pGT1VPs+mc8mUKpm+oExeJFVo2kU1Z8ItPJh6M+UCl0KGq3LFp6xUn5Ex9wWp4gPUT/b81EafH7f2Pv3Dksej0XRwvoeVwY9kPqwDcoBVfFhaow8rd4SlF+MnfYySIY3uzvYYMxyGmhpyxy9yUmuXdKXfZnFSviDoXGsOWRDUHFlntWCywBpxvlLZYClEfKYENWWvrAjYRgqw34HXFHqm3WdL3GK39nKJn2W5Zyz/jp9hYsOjapYbpnoy3WimupqbjKBA0Eki9LNky8q621TOI3L10z6EYgCDBtL1w5LZC1d+h3/Opg4rryEuog9F0o832BQ5YsFHj7qAOcxGtvw7bIz5zRTpdbF8XUq743KVKvzWXhEXd0BOO87XNtol7MLOVzJ1GC3l+WSz4uQlzn4naUUbIB5L7akCtRflz6g9w5HMEkm/W6rTf/eAbYDQQXobIV3tDDet9Kc9R5rS5iC9pukG5TMdmIMEVJ7SdiMLYRKGdijAi0lBU5I6gO8Avl0A3xFxzQH8xW3plefOJ4FRIfWDphwIo4aYWtmsxgQeawLXS1I+i/VZu86X8rlu5JvlbGeTd5VQugtsazdOd4Ftl9w1naNWEsxKPPG+gmm4WpNZkfqaZGonm3eL2z7K0qEKYyiEug0r8ir5CuPiE3Mug6e32G8BboOY9kdUCuXxckgjTG5zFQIXKcFtJCZ5O+ATbdNjWYDAdg6WSxwih4WiHuJ3VZTYVa49IsKwtsiA5M6DHbtWFx5RU3cVx8ll2fA421tdc15SRRwePsHUjpJWlvnhFJXjJ1LxEs1HQTQd2yCGfNRTY4fHOgz1tJnzemIdKu7g2JEl1zAJ7zZjbI4sIZsQHzwNN6/Xwll/X0dDI7b1mKo43axcIMPNQxNQDEUWRxR03Vx4VXeWBxDufTxx5hNU9PjknB3gtwDw//s+MD//+OzdWu7Lj+nH6faf9TdiuOrwvhmHlqNYF+XctEt1kkSSBubJ4DjtMzIQJrkHe59EMcQN0+rpC2nFvHrZCWeILbucfoginBd73yc0D/GDTSgJb9XjEk904c7tVhvFWfU7tVGWN7SJyX2shCQp4VbZ17RBbU3U8FKhaswzW1LUWCpAzTM4nTbSxDBn/VAb71ArFtSUMlKHwoZd6rBYGaVOKNVehlR0Qku0V2xQ+OTOPctHzD1Jj/dptWIFo5jCP27nGQhYvj3fh/w+YQsodL8lJck8TOT7n4n10bXbDq7ELHCezWdePrjvBuDG0txPirOw/v7+Vb67KXYt7fae6ZIk1TQcQOgW1kpXbTmoETDFg20i4163RmjBGiET/eRC9OvWCPUyIp3DH77x2brUV03phJN1XZisG6IfZWXqSIzNNg1BUlOz9XSTleKWiSeYyrnTEl0U+KMJdYf6V4H6HTPUHmZI7ksSM0FT/33t8h78GUbk/NVTLWZIG5wySjalIg62U6jiRmEs0VXj1JCerdVyWzYsPuEqlc2bx8d7ROjcjx4K4rl4VcPZsTtF01ZFUzmsi3IkDeuYTJqk1ToGXyKhfVkhpza5cAKVGRGQ6kA5CGSztu7IW82oQ+X0yxleFRVpmMYTNsD7kwdqAkjV0+mlgWg/F9MYVV8EyYNiSc0tggRnL8n8RdRMjnZ569qhDbHzP4BfghCl+4Ggg07HYWnUQMDZw9k2PX/4YOeDAL7wRDfN0W72IEBfoZMXyV2QO3XVAnVlm9+fFs9/L1/e7D7Nvu+Md2+Gb0tsAd26qHRddLx7VFOhcodrocw3ozL5Vj9tkAZ/Tqd4NCEoLUojVNuRVlh1pLaEa8xvS2yxVGb5Lj6hJYoqe++5qbuGmgJv/9NjQV7w74m3tfA+QOBlB0d6WtnB1z1gHFuGKstVMrVNzqezLR+0t3z+4MyFbQ6fl1awiYANG3ODpDFXsNFKA00x5ylAZgbdHMMtiyTbvqxR0sD+QuvvyOPKMOoeGpDVCuOqzkLKcEgobLR5G+tu9qJEuhxqeP57AO8aW6X5GivLCUDPnKD/TmeiFWO7okSjpRZa0XZR30ILD33PC3mkQW/JB2+Jxur0/w==&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: transparent; background-color: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1986px" height="950px" viewBox="-0.5 -0.5 1986 950" content="&lt;mxfile scale=&quot;1&quot; border=&quot;0&quot;&gt;&lt;diagram name=&quot;L2 Container&quot; id=&quot;fswv24dbm5Xq4Tad-Ww_&quot;&gt;7V1be5s4E/41fp7di+ThDL50bGfbr4ekcbbd9g7bsk2LwQs4sffXf5KQQIizDQ5JSXedIItBCOkdzTujYSCPt4e/PHO3+eQugT2QhOVhIE8GkiQqigh/oZJjWGLIWliw9qwlqRQXzKz/ACkUSOneWgI/UTFwXTuwdsnChes4YBEkykzPc5+T1VaunbzqzlyDVMFsYdrp0m/WMtiQUlEbxl+8A9Z6Qy5tSHr4xdaklcmd+Btz6T4zRfJ0II891w3Cv7aHMbBR59F+kaeft5r/ffrL9eyfylPwbvV9ehUKu61zSnQLHnCCqqLd+U/UnfA021yADew24HE9rnw2t6SXHq0t8IFnwSclCRMzMOGvGfCegEfrPh53pO7YdQLTcpivwGLjuLa7JkNktDMXGwC/eu8+Tm5orQnwF561CyzXCath+eh6AXvxZXhxy4EfX2czNAqcJfx0gw26Iv7+aouGqR9Kts05HLJY4kDSbNhBNyvYQvTAgiMZBdq/e5d+ceXjMTqCFURtd4i/hH+tyW8sZR4XqKSvJJV+Cft5zp8Ay8IrJ4uX1lNUpIbCcGdCYagVmrndwa+cub+j12I6FFZSJ8wFWGG0nV7RFet2iVjUJUTKArbNS0gZwBGpoX9Z56rJh5/oxKwO429TKpsgUjQbowkV36gE5y0euoujbTlwFshQaHjDExE+gpvnjRWAGRyzqOQZoiAs2wRbNKZE1L3uHp61/DinBV5YAI8EeISH3425+LXG5WPSNY7rANRhlm2Po96SJXkkTYakIwlWihI5Zuqt8A8sN21rjabLAs58OPxhwwPP/QWYqsJUn4wm8JstCMzp0gpIK3eu5QR4wqto2AnXsNfHAv4fDagxLBPR0bWkZhRmlenJwrCSmCzLrJghUeAuraI78AB8LOYcPzchevKlsEfgDGJVAA4MwpEB8RdwYdd4cCoJ5FtFUcJTCF7pqhoeP8cKQlII6m8Y3SBSVWASJF1HsmPghX+QUUgPCRSfAMtf32MEPBeQkZiHchwO4ZYA8JOFPgOM46QZo/v3bwNyhR5lT0BZuRBlY1QUyzGVhT/xLBCtBJqmt6BXE+pgKA9IKUyV0qCaBbQRJDaJvnoG/GZBcniJJnH6Urisyt3C5RhxH4Btolnmb6xdHuiSxW+ImrezLx9zAfiT+YvB3zWAzbj10Sec5zIesR74dw/8IH/Fi2dyBu7Ang+uyHxAwGODVZAPPFWlkIlVEcZzUSkLzTNA9exWUQ1QC+9rw6NSCI/AWY6QNQuP5ra7+PW4gRZOLiYKaXRTBPQvQi9qy6Izoexby6ZyUuhmSOgfqmfPcQPQjLSghZwGPCiJNkHBokwvYAt+7re7GbkpCKq0hNTQUotjsIS2OKnvesHGXbuOaU/j0htwsIJ/UO1rlRx9p22Bf08OVBA6ODIH99BehI1H8H7CWtF3994ClOk6uPwxPTQdSywPSUD3WYhwWQjmYRB5SvIUWQhGxN0j7ROjpWwk0VIbqkkR4U2Ss1jOgROkSSWCwl5ICcKAGt1j42vfB7B1Ufd8NOcIHG88C3Vy/cXv/RGOOycXfBmUnQUeMLfoYv5+jqrNwTKHnlh57hb+4tr4ZHnB3sQzH6IS/gPearByvS2mveDHvW0ew0VOLMwPXA/0K+vfd2Wt9ivrfmXd5spaVAQhSXkY3Vpa58L+1whSZxRS7yNI5XXBzF0FzybCUmF29AOwzUX9QrEh+RxSH2Pb3S9fPza/Egxe4J8XwWCtOQyuhbnG2FCGWpOYq8uajtf7Pea+KObq+mvB3DG8dQ+DIMM0WwvAr1fH0To1cwU+W7g7cIPqmqStsN5ot7OhscnQzdkgfQl0bYYrycTobAahFnKf3iQC9mxXF2J+KRjqNcCQX3GWgOPS9DfRuTGUSQIHjQQtU+im4Z80XoY/pehL0RT3pHxDqZARKZ67QQAtOyrF9eC84VsEb81y1o/ujuAoKaB4jG7w3gwgViOBBuw6JQOL3QDONAaLGTrDgzPXdNY2YDiOG8f9SCZI5HS8N5fL8LoCvjHbfR7RgAlUQiIqmKuAww4508MDeJm958OV1gMg3tCQsbHoGZEXEXjTJxCqCnylue/a+wCMYj3Ua5PWuXExSdLIhpBSJkNVSysTddhBbpx3KOaQ4oPI9ciQ4rf+fo7ZM0qJR/wNXL0Pkl7Mni3vKltu9Gz54By2XNEpR4758mtBGrwwZS5W5czlipw5Qb4rCMYC9QQeE7DTAquuakmcFRUOPquy6oqcXP2LPA7nsOqxIFrRXa0w8LXMvLft3SSmxQSsLMcK4U1gwDuM8iOVPpmOtdvbZCnbu0FfEbAPe2A/A9hZUI9dotUxHRnyx3/Yg1CSpNLjWBY+OrJH52mIE52lVVQLG+CZqSEUSUtqCCW9PG5KRUgcr6PwdE1VFSFzgiStORUBZ5l5ZGoQ8yzfm8w7CEShuO05DoVYQ4UtuISneObug82ccFSUwcLPwE8rt+o+AnC9DhHVA5gbCzVU7OOlrmAAlghvx2gkW1uktVxyuDYD8IweAzqYjv9+AxHrvSOhTAGKwqBIA/aehJ77qcn9cJaEoRbotjcUFjkDGHAzwm8ig+CPkOwZSEgiu0MI/gr3CP3Z2wrdtRVEsRAqe2PhZYwF/QLGQvmaXzjLqsgFU4jaOt3TSiDpqijO/NwoTSkJ3trJfBK34DZ4cM8xFs41BIZCPUPAUAoMgRcjt2JjASufsW0BJzjLOohECEvMaDnryETYRuwVLgz1ETIBmLiixF6rLdl1nd7pGumxUMDeD0WGMlCFuem/gdDR3qooVZUsBdJbFb1V0bRVoXXMqkhtgm0UszmITqBxEmTf0t7XHmZLYbbBTa49zPYwCyFUTeKsqHUVZ2HPRKGcPu4sYXz3dTpDk7lihCgPzZG8iWWuPXP7aAU2yIXnxzDiXoEfNA/RIt7dJSxDGQOUBMiL8LluE4U/xpPZ/Z/XqF4k8Em4lq8vh+9vNQ61EJ9rAnHxdlrUoCTaJvEvA2SrBYAGKKwzE9mTLA0HqunoSxZmsyI+09GZOQGZbMxmVjhmj9+XXCaLgpjGb9XIwG/1IvBdj3ynm6sGxbGXM7r9FWfnchnCPdzX2gfgdJlUL95N2pPqOaR6o5Ez2RS9VJ+jrwdrpaw6IbpLSXUSSP4SeQ1EVUlCrqoYSRlVKXNRN0okXTKzQTtIDScKTlhAdrFGQE24DNZ52kN2ZyG7ePNpD9kl0fAJkNXPcISKg+45QrWKkK2+JGRzQGuIJ+aiEXU+rlDjJL1MMpoPjvts466VhI/mEfMRJ6djfJjcwsbcffsIv2UF4wzMA+oGfACm7zJSUth/77lPOLcyfH57G/9G3kB0rg+2pgPnKX60SEzIaPshI+JfkOrok810LdmMWGdzb1ezzfTJZs5nTNa26VMSKcpt3mbeXYPTEkpnqfD3DsoEQ7YfnQ/4n90luP4fciN+A3MfruBQxAsnrgjerURzbNIcNlN64AFwZVt4y2xYFxHcozmcI+YiYBKXkVxjwhJOEeutpFDvFcFJiqB4D+7rUAR92rEOc+c84EeZJTsC+G1Frn/z4GTh32zBUzM+zjbZ0zLdpWWYt7z0tMwJTDrHppxFpJ/N8TTMylQl0qWKrEwUna5oQy46vb3g9NiZSXkbnm2pytvowxJBDUWn6/xeKF0tbhdfX7x0dHq1VzzRZ/dk2nsajhMOxBhv0FJqV28YJ4MMBtGrrGqEL3Hu74x91ZGyZjV4tC2ghgav2FVSRleVL7TJYjKlS6YHlKkrTAWaDiTNWXFzT6beUrkg8I8Cq1jxMUvVl2RR/ELFB3hC+ELF5yc3+vwY47v9hyWOR6OpcbmHlUGQZD4sflNRcw9LafRh5c6wtDXe6mMUNGF0e7HHWBUzT5hy51s5KeMlXem3sU7KLYI+tuYUi6DmzLqoC5PmU+TXK5U9ltwGz5SgphyWFQFbSwH2B3BMoWc6frYkLnZrLZf4WZaHxrJj/AILGxZVxcyVaFu6UU91NbMYQds1J4kNmiWvpKz7Gsp5xK7e7QMoBlBoCLt+WLJ6Ycpv8c/F1GFkhXRSH/KsH+uxKYrEgo8edQGNmI2c+bfYG/ObKdLXRfP1KevOy0Uqsa/uisi4E9JQMMG20VvAXjoNBYkYLSX6RL3i4iVOWicoLSaeEGWO21OFU2OyBL1E0u+WyvTfPaAvOOghvYuQLveem04G1F4iDWlzkF7TdwMRXTZ0IwGVbTpvRI6b15RTAV7m/fS8pB7ge4DvFsD3RFxzAP/izvTKa+dWYJRL0KBIJ8KoxqFo9P6vln3gqlScoY2vT9t1uVTNrbwcpsfp14DT/XtemsPp8P1mJ5Mr+uslV+q/MkZTQlovRsnWFuI6tw7XT938NuQVCC/odS/DqzLpDyDYew6Cd3Zz3CAOoO0BvxOA/98PQ//y84t7YzqHn9PP0+0/6++hzdzjfTNcOs0e0QCXHgN8a3BfPcZVEAy9NThO09UGtw4/mfiO9i80vKJPX0gpXtKXnXCBuNaX0w/R7orF3sMjk7rgE0rCXQ2YTW/9Votuq43itJu92ijLWdTE4j5WQoKQ8OheK4pRWxM1bCpU3W9BTYoapgLUPEZ72kjht1iop9JLQ6VYUFPKSB7qyQvJw2JllDqhVHtpQtEJHdFe8XbwO2fumt5yQFNz3K1WtIB55/p5qakhYHnWfB+wLxJYQKH7bViS3AMefv8rYR/laLdXs5P7lezYvkx26sMn54MBrkzFuZPshfn3j2/i7VWxV7tPTt1v0Mb1qu/ugtDN2UodewtAa7GaLNgmsn30NkIHbIRM9OtfFtbkbuxOvBG47mpduJZ1ocXFusot1jXehVuZOuK3hegV3+1be7WebrJU3DL+BF3q4gu7WgP+aEHdo/6rQP2eGeoOMyReCwJ1QZPQIeXlg4cynMj51lMtZkgx2gzQT6mIk/0UMp+lge6xb5waUrO1Wm7LhsUnvEpl8+7x8R4ROvejh4JQUlbVMH7sXtF0VdFUjiglHEnDOiaTJum0jsGXSGhfWsiozdipoMrUiYBUB9r+JOq1dUeeNSMPpfbNGVYVFWmYxveKwfsTDTkBpHJ7esng/ef8DurqRpBoFEtqzgjigr0E/Y2omRzt8t6xAgti538AD4IA7TSGoINOx8kGiYOA8YfTFOF/eGDnAR8O+FA3zdHrLoGPvkInL/4c9IFWHVNXlv7jafH89/Lwbnc3+7HTPrwbvi/xBfR2UalddH54FKPbGM1WP2jrdC2UOTIqk2/1dywr8Kc9xcO/4j7awVw7kJazOlKvo2gsbotvsVDm+S4+oSOKKvu9F1NnDTUFTj0Occrc7vDQFSbu1sQ5yMFhB2d6WtnB4e5Tji1DleUqmdou5/Z8yye91zJ/cubCNoPPS9PfRMCGnbl+0pnL+WgFQ5H0eQqQqUM3x3FLE9FsD2uUr+R6oVzvwseV4dTl0Dvlm83zuHbCuarSdOD47bCw0fpNrLvpQIl0OdTw7PcA3jX2SrM1Vqbtg4E+Qf+156Llc2hHOY5KPbS876K+hxYeeq4bsEiDRkn4cl55+n8=&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <g>
-            <path d="M 429 750 C 429 741.72 482.73 735 549 735 C 580.83 735 611.35 736.58 633.85 739.39 C 656.36 742.21 669 746.02 669 750 L 669 840 C 669 848.28 615.27 855 549 855 C 482.73 855 429 848.28 429 840 Z" fill="#23a2d9" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(35, 162, 217), rgb(29, 138, 185)); stroke: light-dark(rgb(14, 125, 173), rgb(69, 164, 206));"/>
-            <path d="M 669 750 C 669 758.28 615.27 765 549 765 C 482.73 765 429 758.28 429 750" fill="none" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(14, 125, 173), rgb(69, 164, 206));"/>
+            <path d="M 419 660 C 419 651.72 472.73 645 539 645 C 570.83 645 601.35 646.58 623.85 649.39 C 646.36 652.21 659 656.02 659 660 L 659 750 C 659 758.28 605.27 765 539 765 C 472.73 765 419 758.28 419 750 Z" fill="#23a2d9" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(35, 162, 217), rgb(29, 138, 185)); stroke: light-dark(rgb(14, 125, 173), rgb(69, 164, 206));"/>
+            <path d="M 659 660 C 659 668.28 605.27 675 539 675 C 472.73 675 419 668.28 419 660" fill="none" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(14, 125, 173), rgb(69, 164, 206));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 808px; margin-left: 430px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 718px; margin-left: 420px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#ffffff, #121212); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <font style="font-size: 16px">
@@ -32,20 +32,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="549" y="811" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="539" y="722" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Timeseries Data Server...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="429" y="515" width="240" height="120" rx="12" ry="12" fill="#23a2d9" stroke="#0e7dad" pointer-events="all" style="fill: light-dark(rgb(35, 162, 217), rgb(29, 138, 185)); stroke: light-dark(rgb(14, 125, 173), rgb(69, 164, 206));"/>
+            <rect x="419" y="425" width="240" height="120" rx="12" ry="12" fill="#23a2d9" stroke="#0e7dad" pointer-events="all" style="fill: light-dark(rgb(35, 162, 217), rgb(29, 138, 185)); stroke: light-dark(rgb(14, 125, 173), rgb(69, 164, 206));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 575px; margin-left: 430px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 485px; margin-left: 420px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 11px; font-family: &quot;Helvetica&quot;; color: light-dark(#ffffff, #121212); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <font style="font-size: 16px">
@@ -68,21 +68,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="549" y="578" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
+                    <text x="539" y="488" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
                         VISS Data Server...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 549 635 L 549 718.88" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 549 733.88 L 544 718.88 L 554 718.88 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 539 545 L 539 628.88" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 539 643.88 L 534 628.88 L 544 628.88 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 685px; margin-left: 549px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 596px; margin-left: 539px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -101,20 +101,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="549" y="688" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="539" y="599" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Makes VSS get/set...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="1385" y="765" width="240" height="120" rx="12" ry="12" fill="#23a2d9" stroke="#0e7dad" pointer-events="all" style="fill: light-dark(rgb(35, 162, 217), rgb(29, 138, 185)); stroke: light-dark(rgb(14, 125, 173), rgb(69, 164, 206));"/>
+            <rect x="1375" y="675" width="240" height="120" rx="12" ry="12" fill="#23a2d9" stroke="#0e7dad" pointer-events="all" style="fill: light-dark(rgb(35, 162, 217), rgb(29, 138, 185)); stroke: light-dark(rgb(14, 125, 173), rgb(69, 164, 206));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 825px; margin-left: 1386px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 735px; margin-left: 1376px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 11px; font-family: &quot;Helvetica&quot;; color: light-dark(#ffffff, #121212); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <font style="font-size: 16px">
@@ -138,20 +138,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="1505" y="828" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
+                    <text x="1495" y="738" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
                         RemotiveLabs Bridge...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="1755" y="765" width="240" height="120" rx="12" ry="12" fill="#8c8496" stroke="#736782" pointer-events="all" style="fill: light-dark(rgb(140, 132, 150), rgb(126, 119, 135)); stroke: light-dark(rgb(115, 103, 130), rgb(152, 141, 165));"/>
+            <rect x="1745" y="675" width="240" height="120" rx="12" ry="12" fill="#8c8496" stroke="#736782" pointer-events="all" style="fill: light-dark(rgb(140, 132, 150), rgb(126, 119, 135)); stroke: light-dark(rgb(115, 103, 130), rgb(152, 141, 165));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 825px; margin-left: 1756px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 735px; margin-left: 1746px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#ffffff, #121212); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <font style="font-size: 16px">
@@ -174,20 +174,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="1875" y="829" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="1865" y="739" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         RemotiveLabs Virtual Signal Platform...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="399" y="360" width="956" height="740" rx="10" ry="10" fill="none" stroke="#666666" stroke-dasharray="8 4" pointer-events="none" style="stroke: light-dark(rgb(102, 102, 102), rgb(149, 149, 149));"/>
+            <rect x="389" y="270" width="956" height="590" rx="10" ry="10" fill="none" stroke="#666666" stroke-dasharray="8 4" pointer-events="none" style="stroke: light-dark(rgb(102, 102, 102), rgb(149, 149, 149));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-start; width: 938px; height: 1px; padding-top: 1089px; margin-left: 409px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-start; width: 938px; height: 1px; padding-top: 849px; margin-left: 399px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #333333; ">
                                 <div style="display: inline-block; font-size: 11px; font-family: &quot;Helvetica&quot;; color: light-dark(#333333, #c1c1c1); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <font style="font-size: 16px">
@@ -204,21 +204,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="409" y="1089" fill="#333333" font-family="&quot;Helvetica&quot;" font-size="11px">
+                    <text x="399" y="849" fill="#333333" font-family="&quot;Helvetica&quot;" font-size="11px">
                         Central Data Service Playground Core...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 548.04 262.4 L 549 498.88" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 549 513.88 L 544 498.88 L 554 498.88 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 538.04 172.4 L 538 297.47 L 539.07 297.47 L 538.93 408.88" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 539.06 423.88 L 533.93 408.92 L 543.93 408.84 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 300px; margin-left: 549px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 210px; margin-left: 539px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -237,21 +237,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="549" y="303" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="539" y="213" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Make VISS get/set/sub requests...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 255 400 L 365 400 L 365 765 L 412.88 765" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 427.88 765 L 412.88 770 L 412.88 760 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 245 600 L 275.07 600 L 275.07 675.07 L 402.88 675.01" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 417.88 675 L 402.88 680.01 L 402.88 670.01 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 470px; margin-left: 335px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 642px; margin-left: 315px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -272,20 +272,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="335" y="473" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="315" y="645" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Makes Data Definition...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="15" y="495" width="240" height="120" rx="12" ry="12" fill="#8c8496" stroke="#736782" pointer-events="all" style="fill: light-dark(rgb(140, 132, 150), rgb(126, 119, 135)); stroke: light-dark(rgb(115, 103, 130), rgb(152, 141, 165));"/>
+            <rect x="5" y="740" width="240" height="120" rx="12" ry="12" fill="#8c8496" stroke="#736782" pointer-events="all" style="fill: light-dark(rgb(140, 132, 150), rgb(126, 119, 135)); stroke: light-dark(rgb(115, 103, 130), rgb(152, 141, 165));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 555px; margin-left: 16px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 800px; margin-left: 6px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#ffffff, #121212); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <font style="font-size: 16px">
@@ -308,21 +308,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="135" y="559" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="125" y="804" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Southbound Data Sources...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 255 555 L 342 555 L 342 825 L 412.88 825" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 427.88 825 L 412.88 830 L 412.88 820 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 245 800 L 245.07 790 L 275.07 790 L 275.07 735.07 L 402.88 735.01" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 417.88 735 L 402.88 740.01 L 402.88 730.01 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 790px; margin-left: 342px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 770px; margin-left: 332px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -330,7 +330,7 @@
                                             <b>
                                                 Send timeseries data
                                                 <br/>
-                                                (VSS + other data-models)
+                                                (VSS + other data models)
                                             </b>
                                         </div>
                                         <div style="text-align: center">
@@ -341,20 +341,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="342" y="793" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="332" y="773" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Send timeseries data...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="15" y="340" width="240" height="120" rx="12" ry="12" fill="#8c8496" stroke="#736782" pointer-events="all" style="fill: light-dark(rgb(140, 132, 150), rgb(126, 119, 135)); stroke: light-dark(rgb(115, 103, 130), rgb(152, 141, 165));"/>
+            <rect x="5" y="540" width="240" height="120" rx="12" ry="12" fill="#8c8496" stroke="#736782" pointer-events="all" style="fill: light-dark(rgb(140, 132, 150), rgb(126, 119, 135)); stroke: light-dark(rgb(115, 103, 130), rgb(152, 141, 165));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 400px; margin-left: 16px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 600px; margin-left: 6px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#ffffff, #121212); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <font style="font-size: 16px">
@@ -377,20 +377,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="135" y="404" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="125" y="604" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         DB Clients...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="435" y="140" width="240" height="120" rx="12" ry="12" fill="#8c8496" stroke="#736782" pointer-events="all" style="fill: light-dark(rgb(140, 132, 150), rgb(126, 119, 135)); stroke: light-dark(rgb(115, 103, 130), rgb(152, 141, 165));"/>
+            <rect x="425" y="50" width="240" height="120" rx="12" ry="12" fill="#8c8496" stroke="#736782" pointer-events="all" style="fill: light-dark(rgb(140, 132, 150), rgb(126, 119, 135)); stroke: light-dark(rgb(115, 103, 130), rgb(152, 141, 165));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 200px; margin-left: 436px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 110px; margin-left: 426px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#ffffff, #121212); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <font style="font-size: 16px">
@@ -413,7 +413,7 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="555" y="204" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="545" y="114" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         VISS Clients...
                     </text>
                 </switch>
@@ -424,7 +424,7 @@
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe flex-start; width: 508px; height: 1px; padding-top: 1127px; margin-left: 27px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe flex-start; width: 578px; height: 1px; padding-top: 907px; margin-left: 7px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <font style="font-size: 16px">
@@ -435,30 +435,27 @@
                                         </b>
                                     </font>
                                     <div style="text-align: left">
-                                        The container diagram for the COVESA Central Data Service Playground (CDSP)
-                                        <br/>
-                                        <br/>
-                                        Diagram: v0.2.  Diagram uses the C4 Model for visualising s/w architecture.
+                                        The C4 Model container diagram for the COVESA Central Data Service Playground (CDSP). Diagram v0.3.
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="27" y="1139" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px">
+                    <text x="7" y="919" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px">
                         [Containers] COVESA Central Data Service Playground...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 1625 795 L 1738.88 795" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 1753.88 795 L 1738.88 800 L 1738.88 790 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 1615 705 L 1728.88 705" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 1743.88 705 L 1728.88 710 L 1728.88 700 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 795px; margin-left: 1690px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 705px; margin-left: 1680px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -477,21 +474,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="1690" y="798" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="1680" y="708" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Subscribes to...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 1755 855 L 1641.12 855" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 1626.12 855 L 1641.12 850 L 1641.12 860 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 1745 765 L 1631.12 765" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 1616.12 765 L 1631.12 760 L 1631.12 770 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 855px; margin-left: 1690px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 765px; margin-left: 1680px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -510,20 +507,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="1690" y="858" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="1680" y="768" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Sends signal...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="865" y="440" width="240" height="120" fill="#23a2d9" stroke="#0e7dad" pointer-events="all" style="fill: light-dark(rgb(35, 162, 217), rgb(29, 138, 185)); stroke: light-dark(rgb(14, 125, 173), rgb(69, 164, 206));"/>
+            <rect x="855" y="350" width="240" height="120" fill="#23a2d9" stroke="#0e7dad" pointer-events="all" style="fill: light-dark(rgb(35, 162, 217), rgb(29, 138, 185)); stroke: light-dark(rgb(14, 125, 173), rgb(69, 164, 206));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 500px; margin-left: 866px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 410px; margin-left: 856px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 11px; font-family: &quot;Helvetica&quot;; color: light-dark(#ffffff, #121212); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <font style="font-size: 16px">
@@ -546,20 +543,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="985" y="503" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
+                    <text x="975" y="413" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
                         Knowledge Layer Server...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="865" y="675" width="240" height="120" rx="12" ry="12" fill="#23a2d9" stroke="#0e7dad" pointer-events="all" style="fill: light-dark(rgb(35, 162, 217), rgb(29, 138, 185)); stroke: light-dark(rgb(14, 125, 173), rgb(69, 164, 206));"/>
+            <rect x="855" y="585" width="240" height="120" rx="12" ry="12" fill="#23a2d9" stroke="#0e7dad" pointer-events="all" style="fill: light-dark(rgb(35, 162, 217), rgb(29, 138, 185)); stroke: light-dark(rgb(14, 125, 173), rgb(69, 164, 206));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 735px; margin-left: 866px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 645px; margin-left: 856px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 11px; font-family: &quot;Helvetica&quot;; color: light-dark(#ffffff, #121212); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <font style="font-size: 16px">
@@ -582,21 +579,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="985" y="738" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
+                    <text x="975" y="648" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
                         Information Layer Server...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 1385 855 L 715 855 L 715 795 L 685.12 795" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 670.12 795 L 685.12 790 L 685.12 800 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 1375 765 L 705.07 765.07 L 705.07 705.07 L 675.12 705.02" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 660.12 705 L 675.13 700.02 L 675.11 710.02 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 850px; margin-left: 815px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 760px; margin-left: 804px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -615,7 +612,7 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="815" y="853" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="804" y="763" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Writes timeseries...
                     </text>
                 </switch>
@@ -623,13 +620,13 @@
         </g>
         <g/>
         <g>
-            <rect x="15" y="100" width="120" height="50" rx="7.5" ry="7.5" fill="#8c8496" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(140, 132, 150), rgb(126, 119, 135)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="15" y="130" width="120" height="50" rx="7.5" ry="7.5" fill="#8c8496" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(140, 132, 150), rgb(126, 119, 135)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 125px; margin-left: 16px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 155px; margin-left: 16px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
                                     <font color="#ffffff" style="color: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));">
@@ -639,20 +636,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="75" y="129" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle" font-weight="bold">
+                    <text x="75" y="159" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle" font-weight="bold">
                         External Software Sy...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="15" y="160" width="120" height="40" rx="6" ry="6" fill="#1caae8" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(28, 170, 232), rgb(13, 135, 188)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="15" y="190" width="120" height="40" rx="6" ry="6" fill="#1caae8" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(28, 170, 232), rgb(13, 135, 188)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 180px; margin-left: 16px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 210px; margin-left: 16px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
                                     <font color="#ffffff" style="color: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));">
@@ -662,20 +659,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="75" y="184" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle" font-weight="bold">
+                    <text x="75" y="214" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle" font-weight="bold">
                         Container
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="15" y="40" width="120" height="50" rx="7.5" ry="7.5" fill="#1060af" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(16, 96, 175), rgb(106, 174, 242)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="15" y="70" width="120" height="50" rx="7.5" ry="7.5" fill="#1060af" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(16, 96, 175), rgb(106, 174, 242)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 65px; margin-left: 16px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 95px; margin-left: 16px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
                                     <font color="#ffffff" style="color: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));">
@@ -686,21 +683,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="75" y="69" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle" font-weight="bold">
+                    <text x="75" y="99" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle" font-weight="bold">
                         Software System
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 15 300 L 118.88 300" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 133.88 300 L 118.88 305 L 118.88 295 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 15 330 L 118.88 330" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 133.88 330 L 118.88 335 L 118.88 325 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 300px; margin-left: 75px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 330px; margin-left: 75px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -714,20 +711,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="75" y="303" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="75" y="333" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Relationship
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="15" y="0" width="110" height="30" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="15" y="30" width="110" height="30" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 108px; height: 1px; padding-top: 15px; margin-left: 17px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 108px; height: 1px; padding-top: 45px; margin-left: 17px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #000000; ">
                                 <div style="display: inline-block; font-size: 16px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
                                     Key
@@ -735,21 +732,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="17" y="20" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16px" font-weight="bold">
+                    <text x="17" y="50" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16px" font-weight="bold">
                         Key
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 15 229 C 15 224.03 41.86 220 75 220 C 90.91 220 106.17 220.95 117.43 222.64 C 128.68 224.32 135 226.61 135 229 L 135 261 C 135 265.97 108.14 270 75 270 C 41.86 270 15 265.97 15 261 Z" fill="#1caae8" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(28, 170, 232), rgb(13, 135, 188)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 135 229 C 135 233.97 108.14 238 75 238 C 41.86 238 15 233.97 15 229" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 15 259 C 15 254.03 41.86 250 75 250 C 90.91 250 106.17 250.95 117.43 252.64 C 128.68 254.32 135 256.61 135 259 L 135 291 C 135 295.97 108.14 300 75 300 C 41.86 300 15 295.97 15 291 Z" fill="#1caae8" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(28, 170, 232), rgb(13, 135, 188)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 135 259 C 135 263.97 108.14 268 75 268 C 41.86 268 15 263.97 15 259" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 253px; margin-left: 16px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 283px; margin-left: 16px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #FFFFFF; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#FFFFFF, #121212); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
                                     Container, Database
@@ -757,21 +754,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="75" y="256" fill="#FFFFFF" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle" font-weight="bold">
+                    <text x="75" y="287" fill="#FFFFFF" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle" font-weight="bold">
                         Container, Database
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 925 675 L 925 576.12" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 925 561.12 L 930 576.12 L 920 576.12 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 915 585 L 915 486.12" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 915 471.12 L 920 486.12 L 910 486.12 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 620px; margin-left: 925px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 530px; margin-left: 915px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -788,21 +785,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="925" y="623" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="915" y="533" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Converts to Graph Format...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 865 765 L 685.12 765" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 670.12 765 L 685.12 760 L 685.12 770 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 855 675 L 675.12 675" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 660.12 675 L 675.12 670 L 675.12 680 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 760px; margin-left: 805px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 670px; margin-left: 795px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -819,21 +816,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="805" y="763" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="795" y="673" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Makes query...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 865 500 L 715 500 L 715 750 L 681.12 750" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 666.12 750 L 681.12 745 L 681.12 755 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 855 410 L 705.07 410 L 705.07 660 L 671.12 660" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 656.12 660 L 671.12 655 L 671.12 665 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 575px; margin-left: 715px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 485px; margin-left: 705px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -850,89 +847,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="715" y="578" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="705" y="488" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Makes query...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 985 795 L 985 847 C 995.4 847 995.4 863 985 863 L 985 863 L 985 913.88" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 985 928.88 L 980 913.88 L 990 913.88 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 855 624.96 L 713.07 625.02 C 713.06 614.62 697.06 614.63 697.07 625.03 L 697.07 625.03 L 599.07 625.07 L 599.01 561.12" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 599 546.12 L 604.01 561.11 L 594.01 561.12 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 890px; margin-left: 985px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
-                                <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
-                                    <div style="text-align: left">
-                                        <div style="text-align: center">
-                                            <b>
-                                                Makes queries
-                                            </b>
-                                        </div>
-                                        <div style="text-align: center">
-                                            [RealmSDK]
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </foreignObject>
-                    <text x="985" y="893" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
-                        Makes queries...
-                    </text>
-                </switch>
-            </g>
-        </g>
-        <g>
-            <path d="M 865 939 C 865 934.03 918.73 930 985 930 C 1016.83 930 1047.35 930.95 1069.85 932.64 C 1092.36 934.32 1105 936.61 1105 939 L 1105 1041 C 1105 1045.97 1051.27 1050 985 1050 C 918.73 1050 865 1045.97 865 1041 Z" fill="#23a2d9" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(35, 162, 217), rgb(29, 138, 185)); stroke: light-dark(rgb(14, 125, 173), rgb(69, 164, 206));"/>
-            <path d="M 1105 939 C 1105 943.97 1051.27 948 985 948 C 918.73 948 865 943.97 865 939" fill="none" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(14, 125, 173), rgb(69, 164, 206));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 998px; margin-left: 866px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #ffffff; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#ffffff, #121212); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    <font style="font-size: 16px">
-                                        <b>
-                                            Document Data Service
-                                        </b>
-                                    </font>
-                                    <div>
-                                        [Container: RealmDB]
-                                    </div>
-                                    <br/>
-                                    <div>
-                                        <font style="font-size: 11px">
-                                            <font color="#E6E6E6" style="color: light-dark(rgb(230, 230, 230), rgb(39, 39, 39));">
-                                                Provides get/set operations for embedded Realm application DB
-                                            </font>
-                                        </font>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </foreignObject>
-                    <text x="985" y="1001" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Document Data Service...
-                    </text>
-                </switch>
-            </g>
-        </g>
-        <g>
-            <path d="M 865 714.96 L 723 714.98 C 723 704.58 707 704.58 707 714.98 L 707 714.98 L 609 715 L 609 651.12" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 609 636.12 L 614 651.12 L 604 651.12 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 720px; margin-left: 805px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 630px; margin-left: 795px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -949,21 +878,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="805" y="723" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="795" y="633" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Makes query...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 1055 560 L 1055 658.88" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 1055 673.88 L 1050 658.88 L 1060 658.88 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 1045 470 L 1045.02 568.88" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 1045 583.88 L 1040.02 568.88 L 1050.02 568.89 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 618px; margin-left: 1055px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 529px; margin-left: 1045px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -981,21 +910,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="1055" y="621" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="1045" y="532" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Returns Knowledge...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 1386.2 818.76 L 1382 818.8 L 1382 820 L 1045 820 L 1045 811.12" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 1045 796.12 L 1050 811.12 L 1040 811.12 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 1376.2 728.76 L 1035.07 730 L 1035.04 721.12" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 1035 706.12 L 1040.04 721.1 L 1030.04 721.13 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 820px; margin-left: 1245px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 729px; margin-left: 1235px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -1014,20 +943,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="1245" y="823" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="1235" y="732" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Writes current value...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="1375" y="530" width="240" height="120" rx="12" ry="12" fill="#8c8496" stroke="#736782" pointer-events="all" style="fill: light-dark(rgb(140, 132, 150), rgb(126, 119, 135)); stroke: light-dark(rgb(115, 103, 130), rgb(152, 141, 165));"/>
+            <rect x="1365" y="440" width="240" height="120" rx="12" ry="12" fill="#8c8496" stroke="#736782" pointer-events="all" style="fill: light-dark(rgb(140, 132, 150), rgb(126, 119, 135)); stroke: light-dark(rgb(115, 103, 130), rgb(152, 141, 165));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 590px; margin-left: 1376px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 500px; margin-left: 1366px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#ffffff, #121212); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     <font style="font-size: 16px">
@@ -1050,21 +979,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="1495" y="594" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="1485" y="504" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Onboard and Offboard Applications...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 1495 650 L 1495 705 L 1121.12 705" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 1106.12 705 L 1121.12 700 L 1121.12 710 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 1485 560 L 1485.07 615.07 L 1111.12 615" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 1096.12 615 L 1111.12 610 L 1111.12 620 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 705px; margin-left: 1245px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 615px; margin-left: 1235px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -1081,21 +1010,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="1245" y="708" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="1235" y="618" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Contributing Information...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 1105.72 740.4 L 1555 740 L 1555 666.12" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 1555 651.12 L 1560 666.12 L 1550 666.12 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 1095.72 650.4 L 1545.07 650 L 1545.01 576.12" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 1545 561.12 L 1550.01 576.11 L 1540.01 576.12 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 740px; margin-left: 1245px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 650px; margin-left: 1234px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -1112,21 +1041,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="1245" y="743" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="1234" y="653" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Consuming Information...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 1504.11 511.84 L 1504.1 487 L 1105 487.04" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 1504.12 526.84 L 1496.61 511.85 L 1511.61 511.84 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 1494.13 421.84 L 1494.13 397.07 L 1095 397.04" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 1494.12 436.84 L 1486.63 421.84 L 1501.63 421.84 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 490px; margin-left: 1255px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 400px; margin-left: 1244px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -1143,21 +1072,21 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="1255" y="493" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="1244" y="403" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Consuming Knowledge...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 985 260 L 985 423.88" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 985 438.88 L 980 423.88 L 990 423.88 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 975 170 L 975.01 333.88" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
+            <path d="M 975 348.88 L 970.01 333.88 L 980.01 333.88 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 310px; margin-left: 985px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 221px; margin-left: 975px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     <div style="text-align: left">
@@ -1177,22 +1106,22 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="985" y="313" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
+                    <text x="975" y="224" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         Initialize with ontologies and...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <ellipse cx="985" cy="118.33" rx="28.333333333333332" ry="28.333333333333332" fill="#08427b" stroke="none" pointer-events="all" style="fill: light-dark(rgb(8, 66, 123), rgb(144, 194, 243));"/>
-            <path d="M 865 163.67 C 865 148.02 877.69 135.33 893.33 135.33 L 1076.67 135.33 C 1084.18 135.33 1091.39 138.32 1096.7 143.63 C 1102.01 148.95 1105 156.15 1105 163.67 L 1105 231.67 C 1105 239.18 1102.01 246.39 1096.7 251.7 C 1091.39 257.01 1084.18 260 1076.67 260 L 893.33 260 C 877.69 260 865 247.31 865 231.67 Z" fill="#08427b" stroke="none" pointer-events="all" style="fill: light-dark(rgb(8, 66, 123), rgb(144, 194, 243));"/>
-            <ellipse cx="985" cy="118.33" rx="28.333333333333332" ry="28.333333333333332" fill="#08427b" stroke="none" pointer-events="all" style="fill: light-dark(rgb(8, 66, 123), rgb(144, 194, 243));"/>
+            <ellipse cx="975" cy="28.33" rx="28.333333333333332" ry="28.333333333333332" fill="#08427b" stroke="none" pointer-events="all" style="fill: light-dark(rgb(8, 66, 123), rgb(144, 194, 243));"/>
+            <path d="M 855 73.67 C 855 58.02 867.69 45.33 883.33 45.33 L 1066.67 45.33 C 1074.18 45.33 1081.39 48.32 1086.7 53.63 C 1092.01 58.95 1095 66.15 1095 73.67 L 1095 141.67 C 1095 149.18 1092.01 156.39 1086.7 161.7 C 1081.39 167.01 1074.18 170 1066.67 170 L 883.33 170 C 867.69 170 855 157.31 855 141.67 Z" fill="#08427b" stroke="none" pointer-events="all" style="fill: light-dark(rgb(8, 66, 123), rgb(144, 194, 243));"/>
+            <ellipse cx="975" cy="28.33" rx="28.333333333333332" ry="28.333333333333332" fill="#08427b" stroke="none" pointer-events="all" style="fill: light-dark(rgb(8, 66, 123), rgb(144, 194, 243));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 198px; margin-left: 985px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 108px; margin-left: 975px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#ffffff, #121212); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     <b>
@@ -1207,7 +1136,7 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="985" y="201" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="975" y="111" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Knowledge Engineer &amp; Domain expert...
                     </text>
                 </switch>

--- a/diagrams/CDSP-C4-Model-KL-IL-Component-diagrams.drawio.svg
+++ b/diagrams/CDSP-C4-Model-KL-IL-Component-diagrams.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: transparent; background-color: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="2046px" height="1374px" viewBox="-0.5 -0.5 2046 1374" content="&lt;mxfile scale=&quot;1&quot; border=&quot;0&quot;&gt;&lt;diagram id=&quot;FYA22T1dtodB892g9Xnz&quot; name=&quot;L3 Components&quot;&gt;7V1dd6I6G/01rjXnwi6+BLy0aj/eaWc6tdNOz80s1Ki0CB7AWvvr3yQkGAKoKLR0Ju2cU4khhED2frLz5ElD7c5fz31rMbv2xsBpKNL4taH2GooiS3Ib/kEpa5JiSmqUMvXtMUnbJAzsN0BPJalLewyCRMbQ85zQXiQTR57rglGYSLN831sls008J3nVhTUFqYTByHLSqQ/2OJxFqaZibNIvgD2d0SvLOrnjuUUzkzsJZtbYWzFJar+hdn3PC6NP89cucFDr0XaJzjvL+TaumA/cMOMEb/iE2gPmcKwRmMH7Bj7XZNo3a05us9sb3MCkS3fi+bDmtufCoytrDXz4dwD8F/QhOuluvaAneW5o2S7wByNvAU69pTu2/DXN11ksHHsUlZXMHuVwrCF8WfA3DUV34D2cTmAO1FLhmjS//t/So180A/xydGAGWV+8br6En6bkLy5lyCeM7ZfMUkPwGjYtx566UbEOmIRZxbZISyktWiJsZVxo8jowNXVtmBbdValVakW1YpsYVq7Vy6ufwrw4/o+3Ubd3P7t9mP30Xtrff/W0h6Yev5Dxi7apnOKjRwvQ+TJ5GKSjyuh4NbNDMFjAtwymrCAOwLRZOHdI9rEVzOJzLX9EToVvKyzKdpyu53g+THA9F6afBqHvPQOa2FBUHf+Q6zLp0Q9Mxy/SqTV6nuJ6cuWRxuzhllRP4YscwiZzOiR56IWhN49L8XzYTfgawVuz3emdB2+sJ20S0C1J5AZvrDAEPirQhE2nwdQ5CK3+2A7JjfteaIXWELcoOmkBfBtmAeg6Puyoljt1wM0m8dT1rkgHkWjtbqzxOLquhG/M8VYdCnEohWAgcxXwurDcMTmAl1n6gf0CbkHUlaIssI7kDFTPhWe7sAL9F4gqtFxrGHjOMgSd+OHFOTGitNALKZ2g7tGV8H/oTezixKw0I50ooyNaQjIxK81oZRUpZ1ybT1MyEjOLzLi2xFUS/qOdi4VhAq/oTQOvTBLpXufAg88Y4aREvtUp2RGS1DVyvNowjqGTtBnDNhpNtAiyT+OyN0QAP5A+TQ8JNRxAE7ARut58AfsFvFnULBIhjib876vrrRwwhnwKKwTfuu10Emzhk55tTX1rfmeH8L0k2XogGPn2YkMndzOAeZ9WBxoZ0WkB5nl0pRBn6X6/7w8QmHZhNt9C2NaDfZHUxB6hPDeOtY7gAx58QTf1T279o3tj75YnSim+E1gXCK0qxgnmI7nBCONf4Dt10kDsLdF0RVoGINjcgQb/R42r6NZe7GAJoS1AeACxGj7VFbZ4RgiMR+HSByeCZsuoEvve5ddsJ8HK6laGRRVK0maSBwkVZfDlDn4LEWtlUvSG1KU0XaXJxUekwRAFT2hp8snhG5aSsthG8EpZvKK2ErQiS0aaV1pyBq8YyvvSSg/erXTrLcPsUUaM8OQrMJq5sBNMyX19g8B48r8B/O4BQEtl9AzC1KAlxR43vveCR5aw3yZQ3iFYPo4owkZpoQ9A07GfQQS/MC/C684Q9lFrFAab3EHo+SjTGPYm2wneD4EzsbMQSiZHFrj5YWG4FlHKptW3DjVI1fxtFynaCvK2Vkje0TbEzrr3/OSC+G4UGEHtGDHxA6ztAxyWE6B9MVJGbTBMD5fO8A9DGCPgRiONzZgM2yapAZiEfzKGNAwjCOAuE7hlyUyOCAwzjdyKloHcsnL0iCClNGW/70TmerGcJR0cRDLX5qVHr+sitzmSBsNGJyvAb8lGUtJtFDcH20bwhS7cRvs1SnwLbKMksG4Ud6sNnKkT/JNGuP4r0hTwgGXgTcKVhbllsA5CMM/FL+UY4ElCidk1tTZVXgakzAzdcfsLsvtxxvbJng+wVdnzk0t9fozgWf3DkrudTt98v4el7/mwtMoellLqw8rtYWlTptLHKOlS5+zdHmOG0lRWl9tnCLCx8m+Bgy3wYGYvco32dKYM2/rYMX+xUogVtaeNnmuaZpnqxQxQZbvAANwxHs7Do6EDx0h3MziyybU6pbT9qEnoN7YP6WQYOhOWfWY72cIFohEF/aJ8zhBXgGoUaZMSlkSroOGiLD9kE56W8wXtFNBspSkkh55SNZA+R/N7fjjzph7k0/4mNcNa29qzsOC3rV9lGWg+fm1fkjOKWT2JFHeDDOlNH1VbRvKUwFv6I0BysVOE9ETa9ZWkgZQqCDbvFISpgnBHju+pNJNR0VKA/RWsU+iZlsJ2SFxzezzGz3K3ysW+4+9g2LComqWzqJVxYyvV1IwxAsvECvjQCkCq+YOZhTF5tHZs2HK+upvChlEbXw3jhHis+n0ZwmKoZkhkwPYO6yVr1Po+dKgYxvuZoE/PA0m67t/1nMX96Mf98P7n4LpplmyBxtpZ9aZLV+m2+6epZ7VNUajuQe47GDzAPC2mbX53h57ljxt03uj7ZBInbKbvM2bDMgzSHLMIdW3fHi7DaDIoug4cXgfLeZSSVDij75+Z+atcW+rT6JS10yOz++kI/xSdaSoqUL7+friBFsLt60AOrwdff06+hu0m21+O1CcL6ZEJEYFJJ5B1gB5pqLqB7UmhR76XHhk7GhB4bWWM/qvSI48fR/ITRuw0UefmchuuxhCacAX4q0aeJdWKAnahaaTCKCcGwYcMgpFfzPoXyo5Qhhw/xtWBB71XWhg+WrNHjNcameG3w1/0ZPj5ERfcIkebktDBmjngy8kFrmj8u81eJFZ8NL7dRYp7jOoJDjalE60lK/nQd+hIn+IsP2KP530KD/1VLVmSrKh7jf1h/7DWTDZCovlV1rkLmVrCDRl+iIrkTqfle5NJAI5TH8oniIu7O+TUNrjp3P642oseGG8wQQ51JYfWvuRALNmSeSHTmK01L+BLJBiTJjJUF5NHfMAAflHuyMV8Fsqfx8699Gv++4fqrr/3vzZ//56YzX0FWgbKVVp4FVDeSpnMXBn7Q7nBybj8/HVZUJ5X5dya8SdoUh2xP7XKZZvrLk8XYo3LZ1zjkgn/Yo2LWOMi1rh8kISkcFSR5T4iS3ojLdAb76IgbUjiFlgOWoFxAd8qRzgk10zoFw7JabZ7/Ok4b+rZ8M0IWs7jaag8O60y9X7hj/yXg7fOuSOb7+iOXAy8L70QLyYR4C3A+xODtyLAW4B3ReCtZ6wCrAd497zRch4t5eYXaOfKMnkwjq343uk+iI10ReUMK1GSB8es1CGHrLQG8yEYo+6mSHRoYLGahESv8tmRWbfmCDvcYbCg16o5TGc72fR19JsjcpXmZPP86/nq5ep8sQqbqz6YPhiBpewwurNcK4P9RaaUm2VSzi8E7IraUSI/TIYelDTQ53vppJG9b/Q6vTSyp5C8fHwuG3V5MioBhWXjs5jQd/YcBMC3MTYyOLxVHc+D4Q58m3EIi0vvbgsa4/JxvAv24qzRfD9AJnnkuuiFs9iobs5RWIw/xDYWCFwEgSd2a2gPHs6vHh+vry8no+lb+xgEbgkE/qsQuG52cDEXFWyKDnpfcyEVZhjj0fYZkjJ8+F7HR4PlEGUeCmeVg2pVurPK6eX/FuqiY1vGpDvTVnf9xcWV8GQ8zJOR+B5Sn8JDfQ/Tni+khT/G+4X1eMxX+zkvmdwByv5eMtKJpKn5KHmsj4zWkhOQ3DK1k1aylH29ZNq856Si8EWV5CajcVdqJx0ei+aviZNMMfa5m/n2JJbQi3DPl5h8/hHsU1/20QT7CPbZm32UNPvkD84KsY+aXo9bFvvohs4xRvtEPnClPXV83JR1rItm+lK1JoRNJNWuhdAihxi+9EDzn84SPkrKB2KY8rmJYm+fekEUO4lC+QCmUKqjir2XZm3jlAL+/JKpVjdW0dscwvOBA/amCn6gwhdUlje/xIXHM+Xt45TUCUYtvfkFLwle2oOXtodjFbxUhJeMCnnpeCYpwBCyTiNbV6FmSRxFmHyQoEO1rDZfUGUUYRSkCFqzz0wR+0aDYDyGRDCIunHAWfPVAh3tTb131m6wevhvquo75oIFB+wMBqEcHwwiF9/LXtArnagyDXtXSWiGFmcdHxyagS8ptYtPCWLROvM2PzX+3oJw6WO/TBeseBCGLcjssyMgua6QrAhIPsYs35jiMSCXH1KnpPAKqiTr1cGxYuwA0f2D5HIlGYZZjbWdd6EdxvOHQjkTO8FzUZdALvE8yu9cUzVqKKf4Xw60k7KxAyizOIr4f355CjwXbccG28NroI1ircWM+fq2d4a+jXxDidqDNpizcongUzmFigVTSV7JhCex2lUsmKps952auepXFuySDSIsJI662dOZuCemX4+zp1VDZw3qE0mqKE5lGeEnIdgZVQrYJg1RRj3k28qBNrXKKdh07rH8kGWt7At9ZkF6Fobxdxkrpdwxbycz2gdnMgtN5BNguCkw/AAMz0Xd/dFUk2WzOjSVOStS4cM27i8YcyWpfEisstA0VeVd84E7TqgJ/CZEDBQ97iARgzWku47N5MyypdFlEE5nxZrEKsa2veXnlmtNGQUktILnAL+m4Qyvhv16JbSNv0bbaAttQ2gbpWkb7RwuqYm4kYjDCI1Y4Dc7Y2txGGR3d+jOOAwoibmFsBX+OWfE5Wh/NILJPqkO/DhcUy1F+gJOpih6Fw5UisN/wSr5OJLMBJ00nmxQnJSzdLAPSXQEXsFoiX0L/1visAf5q6IEsP9pwB6NVQWyC2QvAdl1qd7AXrEGQjCWkTziaUNsbo+S05dCCamjEiIL95CP376pDGFFMat0/WjlIF1x1w+upJREU5rrB3+hHTEDdp1QE2GlREwPfXs6xdZ1hgVO7fQoLuMG4WHvRuXjaGFdTAj2wqEH2NAWQQbqDPcixs0HKd+S2jY55KsOr3nJIbWjw754TbeWyy2otHUxOTUuWrEdaP2a2aLvLoqzEjUF3waNRdjASyGJ8lFYgLntnXmvuZgvoqYLPaVMPWX76EHIKUJO2V9OUTkDXFa3MOTnl1MyjefoIxGmhSFdY0N6+9Z2wpCuNlxXLtzsXFVD3eKK+Ky0q1vkaPA7jaoHWuoaV5BS0Qp2/jqa+ofLJJfuBMDXDK9xgeS/dNClvwipo+4IrW6f6hMIvctRu222EyitaUqNcRrFGtGoN3UlzoXcbJ92aDiqtNahqJVAde6F/jKsRub0WmB1nbFaxA05EqvbSayWdaPuWK20K8Nqk4uZpB4B1WqypHY1VnXuhf5YqKYeJYz8za+oiVaZiwU1nwHAxbziR62oqdTxQ5U5VeHgFTV8SZWtqElVedeKmh0n/HnQe+naoQ2x4w00Yids1q+Dc5tmIPiLDxbQroZva7RkfbgMbBcEKBc6ebQJCrJcQBQHAr3rht7K6rc+fVo9ziTbeTtfgfNv/16JqH1HWt/vECEq8DR7fOWOfmmrF3c8ebm9OAsztyAqyT43lMgztBrRm5vpa8qH+qfwJaXk85JYJd5dgta4llFYsx1M+u4UgjT27mgwPiY9b25hNw/wugD+xp8k5hn4ngY0FEkGi+QCemH/jC2OGEc6XGyD8FyIzO9quRDJYOHYCmYxiGCXhyDp8sB5LkimphjDFPhRN4ecnSnprprzVxya62SknSyix5Xh6nDo3pS1cDlo0d018b64sNLG6YYn6YsS8yZkU/Z7AO8a+2qwOSaWE4CG0UP/SnFc0DkDsrnVty/hucDj3qfwXBDD9k9o+P140e8W3aeJNP33KXiaf/s6W78Iw+8PjYOh7Bhr7x8HgyupsuUaqQspO0btO06oiUVWJvIuhwHaAgUvw0Pr66KYzAzS2nj2C42+Y8cyAb11hV5FQO8hY+4yd1/cDODllskM4dHGVhKdT3vP+bOdA3ml8DheMir0iTD4KEkHO69xBaXs4pJoRleTa3DkP2CWjYTDGFx0ule55MGs+wjA3HJhh27gFdoIFZMsMkELtiFpYHAki7gDEZO01mQiZt+OEXBRDFIq20Z0oivF3SfyqMmobrvHfUXhsjbzMluSVt2opcV5FjcP3cxLVjhXvXZVoxaDc7BryrK6vWr8GWYtJxvZkFBzDz3UK2uIyOPUt7GozBMVCmVt2eyKRY6lbtawB24Tk2P+GYQ+sOaYqeiuj3hIA7tHQJbF0HWHE9+bN9BqyUQdX2w/XFoYAyE+4w/wVkO0gpEOnW4cax0tK2vwixhzSE4sXSzUCnssXYSmBaWJTUa1r6PfrHMPWOKYS6Lf1bViXkyfJ2+TH9/ebh8U/fSiNhsaKGpH6bXTLByL/8XXMvaNXofq6GIt43sE/dO4ick2ZcmaLGbMRfj7GD0HFD1vYvTkYX/gTcKVhWBTGqyDEMxzAf5+KyhHy81nqJyR4y3Hnx+GPwncjvDPh8DtdgGsENwWgleza2ptvUx4NVTdwIMcAa/vBa8mv19vzeC1mIRDIbixfb+YeBd0OgUQ28wRpgq9vx4STSbcCYnmuDh7jYSoohwl+CfFHqWi5ef5g4ykOpPPjnuIM5UIMZxGYUjc+sS9hRh+IU6qpBwhpgay+r6YTPxhqFXLe8OwsoUA57qCsybA+RBwzgzmYRSH0w+QzreB7k5w3tfdpwpw1jlIbR/s28P7Trd507i+4LzvDosPPvK/Rd8tffw6wEGG5Sy5Hbw8ZseAAKvPAqtrgdXq5OrWu+hcr+X+N0O+C8+7twPhs1giVn+E6VskZKqRP6g/Fkc1eg5Fv7Z50tYOhFI+dnRlE46pC9Vy+rAYmF96d71TCuRngx/5XiwxnLNWNW9xCwSvEYK//vt09Wtyfqo9W3fur5uw8/NOFgheqhRynOvjsaZ7qUrIxG4N7cHD+dXj4/X15WQ0fWsrRWmjKZ3oLbNC53qNcy4xjdZhrKGbWrIgjSuoNN96zrlSSobs23mC8e4h/uCh73khezZab3TtjRGc9/8P&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: transparent; background-color: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="2046px" height="1350px" viewBox="-0.5 -0.5 2046 1350" content="&lt;mxfile scale=&quot;1&quot; border=&quot;0&quot;&gt;&lt;diagram id=&quot;FYA22T1dtodB892g9Xnz&quot; name=&quot;L3 Components&quot;&gt;7V1rd6I6F/41rjXng13cBPxotbd32plOddrp+TILNSotggew1f76NwkJQriJQktn0s6sSgxJCMmz936yd9KS+8vNhWusFjfOFFgtSZhuWvKgJUmioIvwD0rZkhStqwYpc9eckrRdwtB8A/RWkro2p8CLZfQdx/LNVTxx4tg2mPixNMN1ndd4tpljxWtdGXOQSBhODCuZ+mBO/UWQqkvaLv0SmPMFrVlUu8E3S4NmJk/iLYyp8xpJks9act91HD/4tNz0gYV6j/ZLcN95xrdhw1xg+yk3OOMn1B8wh2VMwAI+N3CZLlO+GUvymP3B8BYmXdkzx4UtNx0bXl0bW+DCv0PgvqAPwU2j7Yre5Ni+YdrAHU6cFTh11vbUcLc0X2+1ssxJUFY8e5DDMsZwsOBvWpJqwWc4ncEcqKf8Lel+9b+1Q79oe3hw9GAGUV1tdl/CT3PyF5cyZhOm5ktqqT7Y+G3DMud2UKwFZn5asR3SU1KHlgh7GRcarwemJuqGacFTVdqkTtCqaBfDxnUGWe2TIgPH/fE26Q/uF3cPi5/OS/f7r4Hy0FbDARkOtF3jJBe9WoDuF8nLIBNVRNevC9MHwxUcZTDlFeIATFv4S4tknxreIrzXcCfkVjhaYVGmZfUdy3Fhgu3YMP3U813nGdDEliSr+IfUG0kPfmA6HkinxuR5jtvJlEc6c4B7Uj6FA9mHXWb1SPLY8X1nGZbiuHCasC2Cj2ba85EDH2wg7BLQIwnkAW8N3wcuKlCHXafA1CXwjbOp6ZMHdx3f8I0x7lF00wq4JswCUD0unKiGPbfA7S7x1HauyQQRaOtujek0qFfAD2Y5rz0KcSiFYGCkFrBZGfaUXMBq1q5nvoA7EEylIAtsI7kDtXPlmDZswNkLRBVarjH2HGvtg1748sKcGFE6aEAKJ2h69AX8H43EPk5MS9OSiSK6oiXEE9PStE5akWJK3WyalJKYWmRK3QLTSPiPTq4oDBN4RSMNbCJJZHpdAAe+Y4STAvlWpcKOCElVIdevO4mjqSRtEZE2Ck00CLLPw7J3ggB+IHOaXhLRcICYgJ3Qd5YrOC/gw6JuEYjgaMP/X23n1QJTKE9hg+CoyxcnXo48GZjG3DWWI9OH45JkGwBv4pqrnTgZLVBFfQXJWqJ3TMK2QY0jKMPDQh9V6wf5v9+fDRGy9mE210B3DeDEJM0yJyjPrWVsAyyBF1/QE/6T+TDBg0YfnZWaQvhY3gmqLWhXAO8vwol8wsVhFU2Kjo/slhUKQlHOlYSoQXHxFpdXRGSkyLUCOeQj6ZIqSnfCV0iKlaQQcBG4RwCdFTxJIZEhF6KiI00qcPyvCv/lTgz+RUFL4n9HTMH/94b/AXxa4c5Z++nWQAi+5CswWdhwEszJc32DKH3yvyH87gFAjWLyDPyEcZFA+VvXecEWIJy3MQC2CMxOA/Q2UZrvAtC2zGcQgD7MixC3N4Zz1Jj43i635zsuyjSFs8m0vPdD4FTsLIWScQsAdz8sDLciSNn1eq5JQJrm5lVSthfEvF6IP1EeYqc9e3ZySXzXSlg6BZYNawjlGyJRmQDNl4k06YJx0qw5xz8RgTEBdmAR7GwnbHYkDCUB/6SYHhGJwIG7SuAWBT2uuWt6ErklJQW5Relo6E4wQunjndBRL4a1pkp8QEftBj0arqvM7ogrDDs+q4R8i3eSlOyjsDuifQQHdOk+2q9TwkeIdkoM6ybhtNrBmTzDP0mEO9sg2x/bEkNn5r8aWLYMt54Plpn4JR0DPHEo0fu60qUMyZCUmcIP5g+Q4tcZ6id7vsBObe9PrPT9RYjJ+l+W2O/1zvT3e1nqni9Lqe1lSZW+rMwZllRlan2Ngir0zt/tNaYwQlVNuX1MgJ2WfwcsrIF7C3OVqbQnM6Xo1sfa/OVKIVrUnjp6pmqapqqXU0ClfIIB2FNszsOrsQVtpNECWjaZWqeQ1B8VAf2G+iFdtEJ3wrLPTSuduEBiREK/KJ81xg2gHEVSpYQl0SYouCjD9aMJT+vlik4KqLbSFJJDTbAaiDqj+R3XXzhzB8rTs11qiraWO7MwF5c3r9IUNBcP25f4yl/aTCLF3SJFejdH5Y4Wv8Vz1u4EkFzRpTx6I536UlxBShQEu3cO/ERBeCKHz1SZyigpCcD+CrYJ9ExSYQUU19KcTvG7LGa5omP8HRSbKKqm8SxybbKxk+jqiDLSbwXk9NjwQKL7vYWBMXmytUzYc65cLMLGQR9fj8OE0Fb9vvZhMZQzJDRgt0B7SbNa30ccSpr2firo0/NQEG7ORgNrdT/5cT++/zm8aesVa6Ahd1a/6tKX+t2z08S7ymMU6nuR+xqDB6in5bjN7/bYMdxpiy7pfJ/NwoTdMnvKqlWKQpqhFqGp7ZrjtY8WcWk90Lz21ssgJc5wBt8/R5aWMnWpT8NTNo6PTJ+nE/xTdqWpLEG5+f1wCzWEu81Q9G+GX3/OvvrddnS+HMlPluIjYyRCJJ1A1gF8pCarGtYnOR/5Xnxk6BBA4LWTYv3XxUceb0eyC0bRZaLe7VUeroYQGlul/6ssz4paRQG71DJSaZTjRvAhRjByWdn+QtkRypDrx7A58GKwoYXhq230KuJdRlb4Tf8XvRl+fsQFd8jVriR0sY1csOVkAldg/+bpi0SLD+zbIqG4h1VPcLAtnCgdUcqGvkMtfYqzrMUervuUNv1lJV6SGPBDhbY/nB/GNpKNCNHsJqtMRboScxeGH4Iimdtp+c5s5oHj2IfqBcTlaIScz4a3vbsf13uJh4ijFhcOTRUOnX2FA9FkK5YLqcpso+UCriImMWliRNSFwiO8iAB+WdmRiflRKH+eWvfCr+XvH7K9/X72tf3790xv70vQRqBcpoXXAeWdhMrMlLE/lGsMjcuuX1cF5VlNzmwZe4MiNBH7E9EoeV61rLjgsSifMRYlFf55LAqPReGxKB9EIUmMqEhzHxEFEsMZI+i1d2GQdkLiyvGxP/IlHFUWd0huGNHPHZKT0u7xp2W9yefjN83rWI+nvvRsddpSCWnH/ZE5eOeBt8q4I6spgSQfSf/vwHsEdQsPahgYRyMBeLmqfRaO9+CMwMF9V85ocJqJ3Lh8VJ8frTwK1/dDJAyCdVfHX4Rw3sYBhn8IKqvGEuGGPfZWtK6GQ3T6Gu2Zin7rXqOdmZ2xOXy4uH58vLm5mk3mb12pYI02zTOHKLlipxjFE146cTaoFKhLck8K3HgiokFKgnz2Im8S1c+0QW+QRPUEilePzVUjLiuIKkBgUWs2Apfj10cL15z5mYB6B4wp1vLOkQrtwlEdXn0Zrsco9xj8k4manGl/T6b99Op/K3nVMw1t1l8or6Oz1eV1W8kFMr4Mm7EMSxZO6YLooQunSdqe9PDHUPfR5dpsUyVO8WeLx/0pfuFEkJPunFUR/KqmxhBZk7on4oGO2pQ335V1LMOfrKrRC667PTL6BkKLDMHwZQDa//TW8FVSeZAjKkJJwQVFcwXF3kuyXFAUCgrpAySFVJ+o2NuzJ0+mlFgOFnRZrk9adBmEZ/3O9xYVrIcQW1BVi8ECE12ti0JuwxI3aI1cDK7HUzRC3nNH0aYJnvP2xgA95U2+t7a29/rw31xWC6gWLngKHUWl4x1FM8VA1c4+woks0pC4Wtw2Owz0Hey2yZaU2ImvAktgm/qYnxp/74C/dlEQlWCDVxaEYQ+qOLI+HHIckpsIyfkrlhySC2wB4rpPzAHqfF+xu31FrpeyIKr1wbGkFYDo/gH0TEmaptejbWdVVKA8fyiUR/wqHRtNCSd1kbXAWWbSkk7xvwxoJ2Xj9dWI1wtZXv3y5Dk22kUV9ofTQpu9G6tF5Ou7wTn6Nlh6JRQT2iTWyBQEn2rNlXvCxOVKKjxVGPnKPWH+ck+YxM5877gx34cGwkY3GOAUR9P06VTc49z6cfq0rKlRhfpEEGqKYa0iNBWCnaZJ9enUOg1fog4oXelAnVqW0onl6sOZOrkM9qckpBe+n7093hDOFlZPjnAfjMrMOZFPgOE6x/ADMDwTdfdHU0UU9frQVGS0SIkN6dyfMGZKktlwmarQNNFkrWA9sOCGhsBvjMRAkWUHkRhRRbpvmZGcabo0qgbhdFocKmYx8o6EWRq2MY8wIL7hPXt4mPoL7Gz+9ZpzG38Nt9Hl3AbnNirjNroZsqQh5MYOq++AAZVY4LZ7U2N1GGT3C3hnHCJMgikRtsI/FxFyOdg7lWCyS5oDP463lEsRvoCTOQrLxEHMOK4TNslFz+jM0E3T2Q7FSTlrC/uQBFdgAyZr7ND43xpHFWW7vHNg/9OAPbBVObJzZK8A2VWh2cBeMwdCMDZCeYTLhljdnsSXLzkT0kQmROTuIR+/tWMVxIqk1+n60clAuvKuH0xJCYqmMtcPtqL4Boqlb2gIsVIhpvuuOZ9j7TpFA6d6erCJ+g7h4exG5eNg/D4WCObKohdY0eYRpE2Ge76T7wcx34Lc1Rnkqw+vWcohsdvTvnitKwUFVRYXk9Hisg0rQOtNao++Oykepagp+LboVh8tHH9JmI/SBMzd4NzZZGI+3w6L8ylV8in51gOnUzidUuZc9Tiki3KOhPz8dEqq8hx8JMQ0V6QbrEjnb3vLFel692LJhJvCqBrqFlfGZ6VbX5Cjxu5Czh5euHcEO1NQ4iy9ijR1th5F/sNpkit7BuAwwzEuUPivLVT1F051NB2h5fylPo7QRY7aXb0bQ2lFkRqM023hRFSoN3UtzoXMap9y6F4jSa6jrkOEsir6y7AaqdNbjtVNxmq+b8iRWN2NY7Woak3HaqlbG1brzJ5J8hFQLcdL6tajVWdW9MdCNfUoidDfbERNEGXOA2o+A4DzdcWPiqip1fFDFhlW4eCIGrak2iJqEk0uiqgpuOHPg94r2/RNiB1voBU6YUf9Ohi36QgEf3HBCurVcLQGIevjtWfawEO50M2T3aYg6xVEccDRu2noLb3+VudPr48LwbTeLl7Bxbd/r/mufUdq3++wQ5TnKOb02p78Ul5f7Ons5e7y3KfB7IX7+h2gn2tSjQcya8xKX1s81D+FLSlBn1ckVcKtw2mLO02UEekOJmf2HII09u5oRXxMBs7SwG4eYLMC7s6fJJQzcJx6dCuSFCmSCeil/TNyHDGOdLjIg/BMiMyeapkQmXZmJZra2OXBi7s8MJ4Lgq5I2jgBftTNIePgF3pozXKDt+Y6mSgnq+B1pbg6HHr0SyNcDjr08Bp87BRstHa6k5N0oIRyE0rT6PfhCZXRHDPD8kBLG6B/lTguqIwC2c717Yt5LrzPKYzcbOeK348XdbTqP82E+b9P3tPy29fF9oUrfn/oPhhSga29/z4YTEm1hWskKpIKrPaCGxqikVWJvOuxh85dwWF4KL4u2JM5grQmXv1C1nfoWMaht6nQK3HoPcTmrvJorZ0BL3b0iAmPTi0R6Hrae66fFRryUmk7XtBq9InQ2F2SDnZeYwpK6MUViRlVjsfgiH/AKhvZDmN42etfZwqPSNyHB5aGDSd0C0doI1SMS5EZCtiGQgODIwni9viepI0WJnz17RgCF+1BSmnbQJyoUnn3iSzRpNV3lte+pHDumV8lhIneEZT6rJYO41ncZj2Y9w8yZ1z1unVZLRrjYNcWRTm/aewdeiMXG6NbQi0d9FKvjTESHqeuiUllVlAVHvp+u4UzMI9MDuXP0HeBscSSih41iU2alFPgZ66zbKFoyVgbX0zXXxsYAyE+4w/wUX0UwUhNp1vL2AZhZS02iDFDyPHQxVK90PBj4r/LW0m/nD/P3mY/vr3dPUjq6WVjDjSInQK/16nvhbGMGYfA81jGumIZRYVZmOxSKdmQYMZMhL8P0XNI0fM2RE8W9ofOzH81EGwKw63ng2UmwN/ngnIQbr5A5UwsZz39/DD8SeB2gn8+BG7zCbBScFsKXvW+rnTVKuFVk1UNGzkcXt8LXnWp2fBajsKhENzKPy8mPHqdLgGEOnOAqZzvbwZFkwp3nKI5bp+9VoxUOeyA9JDwaUXJngMOeN+Lnck2MuLsTLZ03IOcqYWIYU9VF5j4xL2JGDYQJ1FSBhHTAFp9X0wm/jBUq2W9YaK0BQfnpoKzwsH5EHBO3cxDKw+nH0Cd54FuITjv6+5TBzirDKR2D/btYX2nu6xq3Fxw3veExQcX+d+i79YuHg7QyDCsNXOClxM5McDD7DPH6kZgtTy7vnMuezdb8eybJo78i/7dkPssVojVH6H6ltkyVcs26o/FUYXeQ9Gvq590lQOhlN07urYFx0RFjVw+LAfmV85ocEqB/Hz4I9uLJYTzqFbNatwcwRuE4Jt/n65/zS5OlWdjZP+69Xs/RyJH8EqpkONcH49V3StlQmZmZ2wOHy6uHx9vbq5mk/lbVyorNtrCidrRa3SuVxjnEl3rHCY1VF2JF6QwBVXmW884VwrxLfsKb9DefYs/eOk6jh+9G8Ub3ThTBOdn/wc=&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <g>
@@ -47,10 +47,7 @@
                                         </b>
                                     </font>
                                     <div style="text-align: left">
-                                        The component diagrams for the COVESA Central Data Service Playground (CDSP) Information Layer and Knowledge Layer Server Containers
-                                        <br/>
-                                        <br/>
-                                        Diagram: v0.2.  Diagram uses the C4 Model for visualising s/w architecture.
+                                        The C4 model component diagrams for the COVESA Central Data Service Playground (CDSP) Information Layer and Knowledge Layer Server Containers. Diagram: v0.3.
                                     </div>
                                 </div>
                             </div>
@@ -392,42 +389,6 @@
             </g>
         </g>
         <g>
-            <rect x="665" y="1100" width="240" height="120" rx="12" ry="12" fill="#c2c9eb" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(194, 201, 235), rgb(56, 62, 91)); stroke: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 1160px; margin-left: 666px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #FFFFFF; ">
-                                <div style="display: inline-block; font-size: 11px; font-family: &quot;Helvetica&quot;; color: light-dark(#FFFFFF, #121212); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    <font style="font-size: 16px">
-                                        <b>
-                                            Realm Handler
-                                        </b>
-                                    </font>
-                                    <div>
-                                        [Component: Node.JS Websocket Server]
-                                    </div>
-                                    <br/>
-                                    <div>
-                                        <font style="font-size: 11px">
-                                            <font>
-                                                Provides information layer data in tree-like format. Abstracts data store details
-                                            </font>
-                                        </font>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </foreignObject>
-                    <text x="785" y="1163" fill="#FFFFFF" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
-                        Realm Handler...
-                    </text>
-                </switch>
-            </g>
-        </g>
-        <g>
             <rect x="665" y="890" width="240" height="120" rx="12" ry="12" fill="#c2c9eb" stroke="#000000" pointer-events="all" style="fill: light-dark(rgb(194, 201, 235), rgb(56, 62, 91)); stroke: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));"/>
         </g>
         <g>
@@ -459,43 +420,6 @@
                     </foreignObject>
                     <text x="785" y="953" fill="#FFFFFF" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
                         IotDB Handler...
-                    </text>
-                </switch>
-            </g>
-        </g>
-        <g>
-            <path d="M 155 1111 C 155 1104.92 208.73 1100 275 1100 C 306.83 1100 337.35 1101.16 359.85 1103.22 C 382.36 1105.28 395 1108.08 395 1111 L 395 1209 C 395 1215.08 341.27 1220 275 1220 C 208.73 1220 155 1215.08 155 1209 Z" fill="#23a2d9" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(35, 162, 217), rgb(29, 138, 185)); stroke: light-dark(rgb(14, 125, 173), rgb(69, 164, 206));"/>
-            <path d="M 395 1111 C 395 1117.08 341.27 1122 275 1122 C 208.73 1122 155 1117.08 155 1111" fill="none" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(14, 125, 173), rgb(69, 164, 206));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 1170px; margin-left: 156px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #ffffff; ">
-                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#ffffff, #121212); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    <font style="font-size: 16px">
-                                        <b>
-                                            Document Data Service
-                                        </b>
-                                    </font>
-                                    <div>
-                                        [Container: RealmDB]
-                                    </div>
-                                    <br/>
-                                    <div>
-                                        <font style="font-size: 11px">
-                                            <font color="#E6E6E6" style="color: light-dark(rgb(230, 230, 230), rgb(39, 39, 39));">
-                                                Provides get/set operations for embedded Realm application DB
-                                            </font>
-                                        </font>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </foreignObject>
-                    <text x="275" y="1173" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        Document Data Service...
                     </text>
                 </switch>
             </g>
@@ -533,38 +457,6 @@
                     </foreignObject>
                     <text x="275" y="966" fill="#ffffff" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         Timeseries Data Server...
-                    </text>
-                </switch>
-            </g>
-        </g>
-        <g>
-            <path d="M 648.88 1160 L 411.12 1160" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 663.88 1160 L 648.88 1165 L 648.88 1155 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 396.12 1160 L 411.12 1155 L 411.12 1165 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1160px; margin-left: 524px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
-                                <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
-                                    <div style="text-align: left">
-                                        <div style="text-align: center">
-                                            <b>
-                                                Read / Write / Subscribe
-                                            </b>
-                                        </div>
-                                        <div style="text-align: center">
-                                            [RealmSDK]
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </foreignObject>
-                    <text x="524" y="1163" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
-                        Read / Write / Subscribe...
                     </text>
                 </switch>
             </g>
@@ -628,38 +520,6 @@
                         </div>
                     </foreignObject>
                     <text x="1015" y="959" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
-                        (De-)Auth / Read / Write / Subscribe...
-                    </text>
-                </switch>
-            </g>
-        </g>
-        <g>
-            <path d="M 1048.88 1090 L 1015 1090 L 1015 1170 L 921.12 1170" fill="none" stroke="#828282" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 1063.88 1090 L 1048.88 1095 L 1048.88 1085 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-            <path d="M 906.12 1170 L 921.12 1165 L 921.12 1175 Z" fill="#828282" stroke="#828282" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(130, 130, 130), rgb(125, 125, 125)); stroke: light-dark(rgb(130, 130, 130), rgb(125, 125, 125));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1140px; margin-left: 1015px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #404040; background-color: #ffffff; ">
-                                <div style="display: inline-block; font-size: 10px; font-family: &quot;Helvetica&quot;; color: light-dark(#404040, #b6b6b6); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
-                                    <div style="text-align: left">
-                                        <div style="text-align: center">
-                                            <b>
-                                                (De-)Auth / Read / Write / Subscribe
-                                            </b>
-                                        </div>
-                                        <div style="text-align: center">
-                                            [Service Call]
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </foreignObject>
-                    <text x="1015" y="1143" fill="#404040" font-family="&quot;Helvetica&quot;" font-size="10px" text-anchor="middle">
                         (De-)Auth / Read / Write / Subscribe...
                     </text>
                 </switch>


### PR DESCRIPTION
The developers of the Information Layer Server removed support for the Realm database as a backend when MongoDB deprecated it.

As a result, remove the Realm component from the relevant C4 Model diagrams.